### PR TITLE
LIME-816 DVLA DL CRI names character limit bug

### DIFF
--- a/src/app/drivingLicence/fields.js
+++ b/src/app/drivingLicence/fields.js
@@ -1,4 +1,10 @@
+const { firstNameMiddleNameLengthValidator } = require("./fieldsHelper");
 const fields = require("./fieldsHelper");
+
+const firstNameMiddleNameLengthValidatorObj = {
+  fn: firstNameMiddleNameLengthValidator,
+  arguments: [38, "firstName", "middleNames"],
+};
 
 const dvlaValidatorObj = {
   fn: fields.dvlaValidator,
@@ -18,7 +24,7 @@ module.exports = {
     type: "text",
     validate: [
       "required",
-      { type: "maxlength", arguments: [30] },
+      { type: "maxlength", arguments: [43] },
       { type: "regexSurname", fn: (value) => value.match(/^[a-zA-Z .'-]*$/) },
     ],
     journeyKey: "surname",
@@ -27,8 +33,12 @@ module.exports = {
     type: "text",
     validate: [
       "required",
-      { type: "maxlength", arguments: [30] },
+      { type: "maxlength", arguments: [38] },
       { type: "regexFirstName", fn: (value) => value.match(/^[a-zA-Z .'-]*$/) },
+      {
+        type: "firstNameMiddleNameLength",
+        ...firstNameMiddleNameLengthValidatorObj,
+      },
     ],
     journeyKey: "firstName",
   },
@@ -36,10 +46,14 @@ module.exports = {
     type: "text",
     journeyKey: "middleNames",
     validate: [
-      { type: "maxlength", arguments: [30] },
+      { type: "maxlength", arguments: [38] },
       {
         type: "regexMiddleNames",
         fn: (value) => value.match(/^[a-zA-Z .'-]*$/),
+      },
+      {
+        type: "firstNameMiddleNameLength",
+        ...firstNameMiddleNameLengthValidatorObj,
       },
     ],
   },

--- a/src/app/drivingLicence/fieldsHelper.js
+++ b/src/app/drivingLicence/fieldsHelper.js
@@ -16,7 +16,19 @@ module.exports = {
       : 0;
     const firstNameLength = validators.string(firstName) ? firstName.length : 0;
 
-    return middleNameLength + firstNameLength <= length;
+    const singleName = firstNameLength === 0 || middleNameLength === 0;
+
+    const extraCharacter = singleName ? 0 : 1;
+    //This logic will add an extra character to nameMax (see below) if both first and
+    //middle name fields are used, in order to ensure we remain within 38 characters limit
+
+    const firstNameMin = firstNameLength > 0;
+    const middleNameMin = middleNameLength > 0;
+    const nameMin = firstNameMin || middleNameMin;
+    const nameMax =
+      firstNameLength + extraCharacter + middleNameLength <= length;
+
+    return nameMin && nameMax;
   },
   dvlaValidator(
     _value,

--- a/src/app/drivingLicence/fieldsHelper.test.js
+++ b/src/app/drivingLicence/fieldsHelper.test.js
@@ -2,36 +2,47 @@ const fields = require("./fieldsHelper");
 const moment = require("moment");
 
 describe("custom validation fields test", () => {
-  it("should be false when first and middle name combined greater than 30 characters", () => {
+  it("should be false when first and middle name combined is greater than 38 characters", () => {
     const validator = fields.firstNameMiddleNameLengthValidator.bind({
       values: {
-        firstName: "jjjjjjjjjjjjjjjjjjjjj",
-        middleNames: "jjjjjjjjjj",
+        firstName: "jjjjjjjjjjjjjjjjjjjjjjjjjjjjjj",
+        middleNames: "jjjjjjjjj",
       },
     });
 
-    expect(validator(1, 30, "firstName", "middleNames")).to.be.false;
+    expect(validator(1, 38, "firstName", "middleNames")).to.be.false;
   });
 
-  it("should be true when first and middle name combined less or equal to 30 characters", () => {
+  it("should be false when first and middle name combined is 38 characters plus extra character", () => {
     const validator = fields.firstNameMiddleNameLengthValidator.bind({
       values: {
-        firstName: "jjjjjjjjjjjj",
-        middleNames: "jjjjjjjjjj",
+        firstName: "jjjjjjjjjjjjjjjjjjjjjjjjjjjjjj",
+        middleNames: "jjjjjjjj",
       },
     });
 
-    expect(validator(1, 30, "firstName", "middleNames")).to.be.true;
+    expect(validator(1, 38, "firstName", "middleNames")).to.be.false;
   });
 
-  it("should be false when firstname is only entered and is over 30 characters", () => {
+  it("should be true when first and middle name is 37 characters", () => {
     const validator = fields.firstNameMiddleNameLengthValidator.bind({
       values: {
-        firstName: "jjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjj",
+        firstName: "jjjjjjjjjjjjjjjjjjjjjjjjjjjjjj",
+        middleNames: "jjjjjjj",
       },
     });
 
-    expect(validator(1, 30, "firstName", "middleNames")).to.be.false;
+    expect(validator(1, 38, "firstName", "middleNames")).to.be.true;
+  });
+
+  it("should be true when firstname is only entered and is 38 characters", () => {
+    const validator = fields.firstNameMiddleNameLengthValidator.bind({
+      values: {
+        firstName: "jjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjj",
+      },
+    });
+
+    expect(validator(1, 38, "firstName", "middleNames")).to.be.true;
   });
 
   it("should be true when licence number matches DOB", () => {

--- a/test/browser/features/DVLADrivingLicence.feature
+++ b/test/browser/features/DVLADrivingLicence.feature
@@ -274,8 +274,8 @@ Feature: DVLA Driving licence CRI Error Validations
   Scenario: DVLA Driving Licence Issue date that is greater than 10 years old date error validation
     Given User enters DVLA data as a DrivingLicenceSubjectHappyPeter
     Then User enters date of issue as current date
-    And User enters year of issue as current year minus 10
     And User enters day of issue as current day minus 1
+    And User enters year of issue as current year minus 10
     When User clicks on continue
     Then I see issue date error in summary as Enter the date as it appears on your driving licence
     And I see invalid issue date field error as Enter the date as it appears on your driving licence

--- a/test/browser/features/DVLADrivingLicence.feature
+++ b/test/browser/features/DVLADrivingLicence.feature
@@ -21,8 +21,8 @@ Feature: DVLA Driving licence CRI Error Validations
     And  I see the date of birth error in the field as Check you have entered your date of birth correctly
     And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK
     Examples:
-      |DrivingLicenceSubject          |InvalidDayOfBirth|InvalidMonthOfBirth|InvalidYearOfBirth|
-      |DrivingLicenceSubjectHappyPeter|         12      |     08            |       1985       |
+      | DrivingLicenceSubject           | InvalidDayOfBirth | InvalidMonthOfBirth | InvalidYearOfBirth |
+      | DrivingLicenceSubjectHappyPeter | 12                | 08                  | 1985               |
 
   @mock-api:dl-success @validation-regression @build @staging
   Scenario Outline: DVLA Driving Licence number less than 16 characters error validation
@@ -33,8 +33,8 @@ Feature: DVLA Driving licence CRI Error Validations
     And I can see the licence number error in the field as Your licence number should be 16 characters long
     And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK
     Examples:
-      |DrivingLicenceSubject          |InvalidLicenceNumber|
-      |DrivingLicenceSubjectHappyPeter|PARKE610112PBF      |
+      | DrivingLicenceSubject           | InvalidLicenceNumber |
+      | DrivingLicenceSubjectHappyPeter | PARKE610112PBF       |
 
   @mock-api:dl-success @validation-regression @build @staging
   Scenario Outline: DVLA Driving Licence number with special characters and spaces error validation
@@ -45,8 +45,8 @@ Feature: DVLA Driving licence CRI Error Validations
     And I can see the licence number error in the field as Your licence number should not include any symbols or spaces
     And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK
     Examples:
-      |DrivingLicenceSubject          |InvalidLicenceNumber|
-      |DrivingLicenceSubjectHappyPeter|12345678901112@@    |
+      | DrivingLicenceSubject           | InvalidLicenceNumber |
+      | DrivingLicenceSubjectHappyPeter | 12345678901112@@     |
 
 ####### DrivingLicenceNumberWithNumericChar, DrivingLicenceNumberWithAlphaChar, NoDrivingLicenceNumber #######
   @mock-api:dl-success @validation-regression @build @staging
@@ -58,10 +58,10 @@ Feature: DVLA Driving licence CRI Error Validations
     And I can see the licence number error in the field as Enter the number exactly as it appears on your driving licence
     And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK
     Examples:
-      |DrivingLicenceSubject          |InvalidLicenceNumber|
-      |DrivingLicenceSubjectHappyPeter|1234567890111213    |
-      |DrivingLicenceSubjectHappyPeter|abcdefghijklomnp    |
-      |DrivingLicenceSubjectHappyPeter|                    |
+      | DrivingLicenceSubject           | InvalidLicenceNumber |
+      | DrivingLicenceSubjectHappyPeter | 1234567890111213     |
+      | DrivingLicenceSubjectHappyPeter | abcdefghijklomnp     |
+      | DrivingLicenceSubjectHappyPeter |                      |
 
   @mock-api:dl-success @validation-regression @build @staging
   Scenario Outline: DVLA Driving Licence Issue number less than 2 characters error validation
@@ -72,8 +72,8 @@ Feature: DVLA Driving licence CRI Error Validations
     And I see the issue number error in field as Your issue number should be 2 numbers long
     And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK
     Examples:
-      |DrivingLicenceSubject          |InvalidIssueNumber|
-      |DrivingLicenceSubjectHappyPeter|1                 |
+      | DrivingLicenceSubject           | InvalidIssueNumber |
+      | DrivingLicenceSubjectHappyPeter | 1                  |
 
   @mock-api:dl-success @validation-regression @build @staging
   Scenario Outline: DVLA Driving Licence Issue number with special characters error validation
@@ -84,8 +84,8 @@ Feature: DVLA Driving licence CRI Error Validations
     And I see the issue number error in field as Your issue number should not include any symbols or spaces
     And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK
     Examples:
-      |DrivingLicenceSubject          |InvalidIssueNumber|
-      |DrivingLicenceSubjectHappyPeter|A@                |
+      | DrivingLicenceSubject           | InvalidIssueNumber |
+      | DrivingLicenceSubjectHappyPeter | A@                 |
 
 ##### IssueNumberWithAlphanumericChar, IssueNumberWithAlphaChar, NoIssueNumber #####
   @mock-api:dl-success @validation-regression @build @staging
@@ -97,10 +97,10 @@ Feature: DVLA Driving licence CRI Error Validations
     And I see the issue number error in field as Enter the issue number as it appears on your driving licence
     And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK
     Examples:
-      |DrivingLicenceSubject          |InvalidIssueNumber|
-      |DrivingLicenceSubjectHappyPeter|A1                |
-      |DrivingLicenceSubjectHappyPeter|AB                |
-      |DrivingLicenceSubjectHappyPeter|                  |
+      | DrivingLicenceSubject           | InvalidIssueNumber |
+      | DrivingLicenceSubjectHappyPeter | A1                 |
+      | DrivingLicenceSubjectHappyPeter | AB                 |
+      | DrivingLicenceSubjectHappyPeter |                    |
 
   @mock-api:dl-success @validation-regression @build @staging
   Scenario Outline: DVLA Driving Licence Postcode less than 5 characters error validation
@@ -111,8 +111,8 @@ Feature: DVLA Driving licence CRI Error Validations
     And I see the postcode error in field as Your postcode should be between 5 and 7 characters
     And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK
     Examples:
-      |DrivingLicenceSubject          |InvalidPostcode   |
-      |DrivingLicenceSubjectHappyPeter|E20A              |
+      | DrivingLicenceSubject           | InvalidPostcode |
+      | DrivingLicenceSubjectHappyPeter | E20A            |
 
   @mock-api:dl-success @validation-regression @build @staging
   Scenario Outline: DVLA Driving Licence - No Postcode in the Postcode field error validation
@@ -123,8 +123,8 @@ Feature: DVLA Driving licence CRI Error Validations
     And I see the postcode error in field as Enter your postcode
     And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK
     Examples:
-      |DrivingLicenceSubject          |InvalidPostcode   |
-      |DrivingLicenceSubjectHappyPeter|                  |
+      | DrivingLicenceSubject           | InvalidPostcode |
+      | DrivingLicenceSubjectHappyPeter |                 |
 
   @mock-api:dl-success @validation-regression @build @staging
   Scenario Outline: DVLA Driving Licence International Postcode error validation
@@ -135,8 +135,8 @@ Feature: DVLA Driving licence CRI Error Validations
     And I see the postcode error in field as Enter a UK postcode
     And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK
     Examples:
-      |DrivingLicenceSubject          |InvalidPostcode   |
-      |DrivingLicenceSubjectHappyPeter|CA 95128          |
+      | DrivingLicenceSubject           | InvalidPostcode |
+      | DrivingLicenceSubjectHappyPeter | CA 95128        |
 
 ##### PostcodeWithSpecialChar #####
   @mock-api:dl-success @validation-regression @build @staging
@@ -148,8 +148,8 @@ Feature: DVLA Driving licence CRI Error Validations
     And I see the postcode error in field as Your postcode should only include numbers and letters
     And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK
     Examples:
-      |DrivingLicenceSubject          |InvalidPostcode   |
-      |DrivingLicenceSubjectHappyPeter|NW* ^%G           |
+      | DrivingLicenceSubject           | InvalidPostcode |
+      | DrivingLicenceSubjectHappyPeter | NW* ^%G         |
 
 ###### PostcodeWithNumericChar, PostcodeWithAlphaChar #####
   @mock-api:dl-success @validation-regression @build @staging
@@ -161,9 +161,9 @@ Feature: DVLA Driving licence CRI Error Validations
     And I see the postcode error in field as Your postcode should include numbers and letters
     And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK
     Examples:
-      |DrivingLicenceSubject          |InvalidPostcode   |
-      |DrivingLicenceSubjectHappyPeter|123 456           |
-      |DrivingLicenceSubjectHappyPeter|ABC XYZ           |
+      | DrivingLicenceSubject           | InvalidPostcode |
+      | DrivingLicenceSubjectHappyPeter | 123 456         |
+      | DrivingLicenceSubjectHappyPeter | ABC XYZ         |
 
 ######  InvalidLastNameWithNumbers, InvalidLastNameWithSpecialCharacters, NoLastName #####
   @mock-api:dl-success @validation-regression @build @staging
@@ -175,10 +175,10 @@ Feature: DVLA Driving licence CRI Error Validations
     And I see the Lastname error in the error field as Enter your last name as it appears on your driving licence
     And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK
     Examples:
-      |DrivingLicenceSubject          |InvalidLastName |
-      |DrivingLicenceSubjectHappyPeter|KYLE123         |
-      |DrivingLicenceSubjectHappyPeter|KYLE^&(         |
-      |DrivingLicenceSubjectHappyPeter|                |
+      | DrivingLicenceSubject           | InvalidLastName |
+      | DrivingLicenceSubjectHappyPeter | KYLE123         |
+      | DrivingLicenceSubjectHappyPeter | KYLE^&(         |
+      | DrivingLicenceSubjectHappyPeter |                 |
 
 ######  InvalidFirstNameWithNumbers, InvalidFirstNameWithSpecialCharacters, NoFirstName #####
   @mock-api:dl-success @validation-regression @build @staging
@@ -190,10 +190,10 @@ Feature: DVLA Driving licence CRI Error Validations
     And I see the Firstname error in the error field as Enter your first name as it appears on your driving licence
     And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK
     Examples:
-      |DrivingLicenceSubject          |InvalidFirstName|
-      |DrivingLicenceSubjectHappyPeter|SELINA987       |
-      |DrivingLicenceSubjectHappyPeter|SELINA%$@       |
-      |DrivingLicenceSubjectHappyPeter|                |
+      | DrivingLicenceSubject           | InvalidFirstName |
+      | DrivingLicenceSubjectHappyPeter | SELINA987        |
+      | DrivingLicenceSubjectHappyPeter | SELINA%$@        |
+      | DrivingLicenceSubjectHappyPeter |                  |
 
     ######  InvalidMiddleNamesWithNumbers, InvalidMiddleNamesWithSpecialCharacters #####
   @mock-api:dl-success @validation-regression @build @staging
@@ -205,9 +205,9 @@ Feature: DVLA Driving licence CRI Error Validations
     And I see the middlenames error in the error field as Enter any middle names as they appear on your driving licence
     And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK
     Examples:
-      |DrivingLicenceSubject          |InvalidMiddleNames|
-      |DrivingLicenceSubjectHappyPeter|SELINA987       |
-      |DrivingLicenceSubjectHappyPeter|SELINA%$@       |
+      | DrivingLicenceSubject           | InvalidMiddleNames |
+      | DrivingLicenceSubjectHappyPeter | SELINA987          |
+      | DrivingLicenceSubjectHappyPeter | SELINA%$@          |
 
 #####  DateOfBirthWithSpecialCharacters, DateOfBirthNotReal, NoDateOfBirth #####
   @mock-api:dl-success @validation-regression @build @staging
@@ -221,9 +221,9 @@ Feature: DVLA Driving licence CRI Error Validations
     And I see the date of birth error in the field as Enter your date of birth as it appears on your driving licence
     And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK
     Examples:
-      |DrivingLicenceSubject          |InvalidDayOfBirth|InvalidMonthOfBirth|InvalidYearOfBirth|
-      |DrivingLicenceSubjectHappyPeter|         @       |     *&            |       19 7     |
-      |DrivingLicenceSubjectHappyPeter|         51      |     71            |       198      |
+      | DrivingLicenceSubject           | InvalidDayOfBirth | InvalidMonthOfBirth | InvalidYearOfBirth |
+      | DrivingLicenceSubjectHappyPeter | @                 | *&                  | 19 7               |
+      | DrivingLicenceSubjectHappyPeter | 51                | 71                  | 198                |
 #      DVLA Driving licence with no date of birth scenario is not displaying the expected error message and has been raised as a bug LIME-694
 #      |DrivingLicenceSubjectHappyPeter|                 |                   |                |
 
@@ -238,8 +238,8 @@ Feature: DVLA Driving licence CRI Error Validations
     And I see the date of birth error in the field as Your date of birth must be in the past
     And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK
     Examples:
-      |DrivingLicenceSubject          |InvalidDayOfBirth|InvalidMonthOfBirth|InvalidYearOfBirth|
-      |DrivingLicenceSubjectHappyPeter|         10      |     10            |         2042     |
+      | DrivingLicenceSubject           | InvalidDayOfBirth | InvalidMonthOfBirth | InvalidYearOfBirth |
+      | DrivingLicenceSubjectHappyPeter | 10                | 10                  | 2042               |
 
 #####  InvalidIssueDate, NoIssueDate #####
   @mock-api:dl-success @validation-regression @build @staging
@@ -253,10 +253,10 @@ Feature: DVLA Driving licence CRI Error Validations
     And I see invalid issue date field error as Enter the date as it appears on your driving licence
     And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK
     Examples:
-      |DrivingLicenceSubject          |InvalidDayOfIssue|InvalidMonthOfIssue|InvalidYearOfIssue|
-      |DrivingLicenceSubjectHappyPeter|         AA      |     BB            |         AABC     |
-      |DrivingLicenceSubjectHappyPeter|         &       |     ^%            |         £$ ^     |
-      |DrivingLicenceSubjectHappyPeter|                 |                   |                  |
+      | DrivingLicenceSubject           | InvalidDayOfIssue | InvalidMonthOfIssue | InvalidYearOfIssue |
+      | DrivingLicenceSubjectHappyPeter | AA                | BB                  | AABC               |
+      | DrivingLicenceSubjectHappyPeter | &                 | ^%                  | £$ ^               |
+      | DrivingLicenceSubjectHappyPeter |                   |                     |                    |
 
   @mock-api:dl-success @validation-regression @build @staging
   Scenario Outline: DVLA Driving Licence Issue date that is previous days gets through successfully
@@ -266,9 +266,9 @@ Feature: DVLA Driving licence CRI Error Validations
     When User clicks on continue
     Then Proper error message is displayed as We could not find your details
     Examples:
-      |daysToSubtract|
-      |      1       |
-      |      3       |
+      | daysToSubtract |
+      | 1              |
+      | 3              |
 
   @mock-api:dl-success @validation-regression @build @staging
   Scenario: DVLA Driving Licence Issue date that is greater than 10 years old date error validation
@@ -309,8 +309,8 @@ Feature: DVLA Driving licence CRI Error Validations
     And I see invalid issue date field error as The issue date must be in the past
     And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK
     Examples:
-      |DrivingLicenceSubject          |InvalidDayOfIssue|InvalidMonthOfIssue|InvalidYearOfIssue|
-      |DrivingLicenceSubjectHappyPeter|         01      |     10            |         2043     |
+      | DrivingLicenceSubject           | InvalidDayOfIssue | InvalidMonthOfIssue | InvalidYearOfIssue |
+      | DrivingLicenceSubjectHappyPeter | 01                | 10                  | 2043               |
 
 #####  InvalidValidToDate, ValidToDateWithSpecialCharacters, NoValidToDate  #####
   @mock-api:dl-success @validation-regression @build @staging
@@ -324,10 +324,10 @@ Feature: DVLA Driving licence CRI Error Validations
     And I can see the Valid to date field error as Enter the date as it appears on your driving licence
     And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK
     Examples:
-      |DrivingLicenceSubject          |InvalidValidToDay|InvalidValidToMonth|InvalidValidToYear|
-      |DrivingLicenceSubjectHappyPeter|         AA      |     BC            |         AABD     |
-      |DrivingLicenceSubjectHappyPeter|         !@      |     £$            |         %^ *     |
-      |DrivingLicenceSubjectHappyPeter|                 |                   |                  |
+      | DrivingLicenceSubject           | InvalidValidToDay | InvalidValidToMonth | InvalidValidToYear |
+      | DrivingLicenceSubjectHappyPeter | AA                | BC                  | AABD               |
+      | DrivingLicenceSubjectHappyPeter | !@                | £$                  | %^ *               |
+      | DrivingLicenceSubjectHappyPeter |                   |                     |                    |
 
   @mock-api:dl-success @validation-regression @build @staging
   Scenario Outline: DVLA Driving Licence Valid to date in the past error validation
@@ -340,8 +340,8 @@ Feature: DVLA Driving licence CRI Error Validations
     And I can see the Valid to date field error as You cannot use an expired driving licence
     And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK
     Examples:
-      |DrivingLicenceSubject          |InvalidValidToDay|InvalidValidToMonth|InvalidValidToYear|
-      |DrivingLicenceSubjectHappyPeter|         10      |     01            |         2010     |
+      | DrivingLicenceSubject           | InvalidValidToDay | InvalidValidToMonth | InvalidValidToYear |
+      | DrivingLicenceSubjectHappyPeter | 10                | 01                  | 2010               |
 
   @mock-api:dl-success @validation-regression @build @staging
   Scenario Outline:  DVLA Driving Licence error validation when DVLA consent checkbox is unselected
@@ -352,8 +352,8 @@ Feature: DVLA Driving licence CRI Error Validations
     Then I can see the DVLA consent error summary as You must give your consent to continue
     And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK
     Examples:
-      |DrivingLicenceSubject             |
-      |DrivingLicenceSubjectHappyPeter   |
+      | DrivingLicenceSubject           |
+      | DrivingLicenceSubjectHappyPeter |
 
   @mock-api:dl-failed @validation-regression @build @staging
   Scenario Outline: DVLA Driving Licence number validation test - Correct licence number structure - error validation
@@ -362,8 +362,8 @@ Feature: DVLA Driving licence CRI Error Validations
     When User clicks on continue
     Then Proper error message is displayed as We could not find your details
     Examples:
-      |DrivingLicenceSubject          | InvalidLicenceNumber  |
-      |DrivingLicenceSubjectHappyKenneth| DECER657085K99LN      |
+      | DrivingLicenceSubject             | InvalidLicenceNumber |
+      | DrivingLicenceSubjectHappyKenneth | DECER657085K99LN     |
 
   @mock-api:dl-failed @validation-regression @build @staging
   Scenario Outline:  DVLA Driving Licence number validation test - (VALID, female licenceNumber DOB Jan)
@@ -375,8 +375,8 @@ Feature: DVLA Driving licence CRI Error Validations
     When User clicks on continue
     Then Proper error message is displayed as We could not find your details
     Examples:
-      |DrivingLicenceSubject            |InvalidLicenceNumber|InvalidDayOfBirth|InvalidMonthOfBirth|InvalidYearOfBirth|
-      |DrivingLicenceSubjectHappyKenneth| DECER651085K99LN |         08      |        01       |        1965      |
+      | DrivingLicenceSubject             | InvalidLicenceNumber | InvalidDayOfBirth | InvalidMonthOfBirth | InvalidYearOfBirth |
+      | DrivingLicenceSubjectHappyKenneth | DECER651085K99LN     | 08                | 01                  | 1965               |
 
   @mock-api:dl-failed @validation-regression @build @staging
   Scenario Outline:  DVLA Driving Licence number validation test - (VALID, female licenceNumber DOB Dec)
@@ -388,8 +388,8 @@ Feature: DVLA Driving licence CRI Error Validations
     When User clicks on continue
     Then Proper error message is displayed as We could not find your details
     Examples:
-      |DrivingLicenceSubject            |InvalidLicenceNumber|InvalidDayOfBirth|InvalidMonthOfBirth|InvalidYearOfBirth|
-      |DrivingLicenceSubjectHappyKenneth| DECER662085K99LN   |         08      |        12         |        1965      |
+      | DrivingLicenceSubject             | InvalidLicenceNumber | InvalidDayOfBirth | InvalidMonthOfBirth | InvalidYearOfBirth |
+      | DrivingLicenceSubjectHappyKenneth | DECER662085K99LN     | 08                | 12                  | 1965               |
 
   @mock-api:dl-failed @validation-regression @build @staging
   Scenario Outline:  DVLA Driving Licence number validation test - (VALID, licenceNumber DOB Dec)
@@ -401,8 +401,8 @@ Feature: DVLA Driving licence CRI Error Validations
     When User clicks on continue
     Then Proper error message is displayed as We could not find your details
     Examples:
-      |DrivingLicenceSubject            |InvalidLicenceNumber|InvalidDayOfBirth |InvalidMonthOfBirth|InvalidYearOfBirth|
-      |DrivingLicenceSubjectHappyKenneth| DECER612085KE9LN   |           08     |        12         |        1965      |
+      | DrivingLicenceSubject             | InvalidLicenceNumber | InvalidDayOfBirth | InvalidMonthOfBirth | InvalidYearOfBirth |
+      | DrivingLicenceSubjectHappyKenneth | DECER612085KE9LN     | 08                | 12                  | 1965               |
 
   @mock-api:dl-failed @validation-regression @build @staging
   Scenario Outline:  DVLA Driving Licence number validation test - (VALID, 1 forename)
@@ -413,8 +413,8 @@ Feature: DVLA Driving licence CRI Error Validations
     When User clicks on continue
     Then Proper error message is displayed as We could not find your details
     Examples:
-      |DrivingLicenceSubject            |InvalidLicenceNumber|InvalidLastName|InvalidFirstName|
-      |DrivingLicenceSubjectHappyKenneth|AB999607085J9AAA    |       JOHN    |     SMITH      |
+      | DrivingLicenceSubject             | InvalidLicenceNumber | InvalidLastName | InvalidFirstName |
+      | DrivingLicenceSubjectHappyKenneth | AB999607085J9AAA     | JOHN            | SMITH            |
 
   @mock-api:dl-failed @validation-regression @build @staging
   Scenario Outline:  DVLA Driving Licence number validation test - (VALID, surname < 5)
@@ -425,8 +425,8 @@ Feature: DVLA Driving licence CRI Error Validations
     When User clicks on continue
     Then Proper error message is displayed as We could not find your details
     Examples:
-      |DrivingLicenceSubject            |InvalidLicenceNumber|InvalidLastName|InvalidFirstName|
-      |DrivingLicenceSubjectHappyKenneth|AB999607085J9AAA    |       JOHN    |     AB         |
+      | DrivingLicenceSubject             | InvalidLicenceNumber | InvalidLastName | InvalidFirstName |
+      | DrivingLicenceSubjectHappyKenneth | AB999607085J9AAA     | JOHN            | AB               |
 
   @mock-api:dl-failed @validation-regression @build @staging
   Scenario Outline:  DVLA Driving Licence number validation test - (VALID, 2 forenames)
@@ -438,5 +438,103 @@ Feature: DVLA Driving licence CRI Error Validations
     When User clicks on continue
     Then Proper error message is displayed as We could not find your details
     Examples:
-      |DrivingLicenceSubject             |InvalidLicenceNumber |InvalidLastName|InvalidFirstName|InvalidMiddleNames|
-      |DrivingLicenceSubjectHappyKenneth |AB999607085JAAAA     |       JOHN    |     SMITH      |           A      |
+      | DrivingLicenceSubject             | InvalidLicenceNumber | InvalidLastName | InvalidFirstName | InvalidMiddleNames |
+      | DrivingLicenceSubjectHappyKenneth | AB999607085JAAAA     | JOHN            | SMITH            | A                  |
+
+#  @mock-api:dl-success @validation-regression @build @staging
+  Scenario Outline:  DVLA Driving Licence last name validation test - 43 characters
+    Given User enters DVLA data as a <DrivingLicenceSubject>
+    And User re-enters last name as <InvalidLastName>
+    When User clicks on continue
+    Examples:
+      | DrivingLicenceSubject             | InvalidLastName                             |
+      | DrivingLicenceSubjectHappyKenneth | abcdefghijklmnopqrstuvwxyzabcdefghijklmnopq |
+
+#  @mock-api:dl-success @validation-regression @build @staging
+  Scenario Outline:  DVLA Driving Licence last name validation test - 44 characters
+    Given User enters DVLA data as a <DrivingLicenceSubject>
+    And User re-enters last name as <InvalidLastName>
+    When User clicks on continue
+    Examples:
+      | DrivingLicenceSubject             | InvalidLastName                              |
+      | DrivingLicenceSubjectHappyKenneth | abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqr |
+
+
+  @mock-api:dl-success @validation-regression @build @staging
+  Scenario Outline:  DVLA Driving Licence first name validation test - 38 characters
+    Given User enters DVLA data as a <DrivingLicenceSubject>
+    And User re-enters first name as <InvalidFirstName>
+    When User clicks on continue
+    Examples:
+      | DrivingLicenceSubject             | InvalidFirstName                       |
+      | DrivingLicenceSubjectHappyKenneth | abcdefghijklmnopqrstuvwxyzabcdefghijkl |
+
+  @mock-api:dl-success @validation-regression @build @staging
+  Scenario Outline:  DVLA Driving Licence first name validation test - 39 characters
+    Given User enters DVLA data as a <DrivingLicenceSubject>
+    And User re-enters first name as <InvalidFirstName>
+    When User clicks on continue
+    Examples:
+      | DrivingLicenceSubject             | InvalidFirstName                        |
+      | DrivingLicenceSubjectHappyKenneth | abcdefghijklmnopqrstuvwxyzabcdefghijklm |
+
+  @mock-api:dl-failed @validation-regression @build @staging
+  Scenario Outline:  DVLA Driving Licence middle name validation test - 38 characters
+    Given User enters DVLA data as a <DrivingLicenceSubject>
+    And User re-enters first name as <InvalidFirstName>
+    And User re-enters middle names as <InvalidMiddleNames>
+    When User clicks on continue
+    Then I see the Firstname error summary as Enter your first name as it appears on your driving licence
+    And I see the Firstname error in the error field as Enter your first name as it appears on your driving licence
+    Examples:
+      | DrivingLicenceSubject             | InvalidFirstName | InvalidMiddleNames                     |
+      | DrivingLicenceSubjectHappyKenneth |                  | abcdefghijklmnopqrstuvwxyzabcdefghijkl |
+
+  @mock-api:dl-failed @validation-regression @build @staging
+  Scenario Outline:  DVLA Driving Licence middle name validation test - 39 characters
+    Given User enters DVLA data as a <DrivingLicenceSubject>
+    And User re-enters first name as <InvalidFirstName>
+    And User re-enters middle names as <InvalidMiddleNames>
+    When User clicks on continue
+    Then I see the Firstname error summary as Enter your first name as it appears on your driving licence
+    And I see the Firstname error in the error field as Enter your first name as it appears on your driving licence
+    Examples:
+      | DrivingLicenceSubject             | InvalidFirstName | InvalidMiddleNames                      |
+      | DrivingLicenceSubjectHappyKenneth |                  | abcdefghijklmnopqrstuvwxyzabcdefghijklm |
+
+  @mock-api:dl-success @validation-regression @build @staging
+  Scenario Outline:  DVLA Driving Licence character limit happy path validation test
+    Given User enters DVLA data as a <DrivingLicenceSubject>
+    And User re-enters last name as <InvalidLastName>
+    And User re-enters first name as <InvalidFirstName>
+    When User clicks on continue
+    Examples:
+      | DrivingLicenceSubject             | InvalidLastName                             | InvalidFirstName                       |
+      | DrivingLicenceSubjectHappyKenneth | abcdefghijklmnopqrstuvwxyzabcdefghijklmnopq | abcdefghijklmnopqrstuvwxyzabcdefghijkl |
+
+  @mock-api:dl-failed @validation-regression @build @staging
+  Scenario Outline:  DVLA Driving Licence character limit happy path validation test
+    Given User enters DVLA data as a <DrivingLicenceSubject>
+    And User re-enters last name as <InvalidLastName>
+    And User re-enters first name as <InvalidFirstName>
+    And User re-enters middle names as <InvalidMiddleNames>
+    When User clicks on continue
+    Then I see the Firstname error summary as Enter your first name as it appears on your driving licence
+    And I see the Firstname error in the error field as Enter your first name as it appears on your driving licence
+    Examples:
+      | DrivingLicenceSubject             | InvalidLastName                             | InvalidFirstName | InvalidMiddleNames                    |
+      | DrivingLicenceSubjectHappyKenneth | abcdefghijklmnopqrstuvwxyzabcdefghijklmnopq |                  | abcdefghijklmnopqrstuvwxyzabcdefghijk |
+
+  @mock-api:dl-failed @validation-regression @build @staging
+  Scenario Outline:  DVLA Driving Licence character limit happy path validation test
+    Given User enters DVLA data as a <DrivingLicenceSubject>
+    And User re-enters last name as <InvalidLastName>
+    And User re-enters middle names as <InvalidMiddleNames>
+    When User clicks on continue
+    Then I see the Firstname error summary as Enter your first name as it appears on your driving licence
+    And I see the Firstname error in the error field as Enter your first name as it appears on your driving licence
+    Then I see the middlenames error summary as Enter any middle names as they appear on your driving licence
+    And I see the middlenames error in the error field as Enter any middle names as they appear on your driving licence
+    Examples:
+      | DrivingLicenceSubject             | InvalidLastName                             | InvalidMiddleNames                      |
+      | DrivingLicenceSubjectHappyKenneth | abcdefghijklmnopqrstuvwxyzabcdefghijklmnopq | abcdefghijklmnopqrstuvwxyzabcdefghijklm |

--- a/test/browser/features/DVLADrivingLicence.feature
+++ b/test/browser/features/DVLADrivingLicence.feature
@@ -441,7 +441,7 @@ Feature: DVLA Driving licence CRI Error Validations
       | DrivingLicenceSubject             | InvalidLicenceNumber | InvalidLastName | InvalidFirstName | InvalidMiddleNames |
       | DrivingLicenceSubjectHappyKenneth | AB999607085JAAAA     | JOHN            | SMITH            | A                  |
 
-#  @mock-api:dl-success @validation-regression @build @staging
+  @mock-api:dl-success @validation-regression @build @staging
   Scenario Outline:  DVLA Driving Licence last name validation test - 43 characters
     Given User enters DVLA data as a <DrivingLicenceSubject>
     And User re-enters last name as <InvalidLastName>
@@ -450,7 +450,7 @@ Feature: DVLA Driving licence CRI Error Validations
       | DrivingLicenceSubject             | InvalidLastName                             |
       | DrivingLicenceSubjectHappyKenneth | abcdefghijklmnopqrstuvwxyzabcdefghijklmnopq |
 
-#  @mock-api:dl-success @validation-regression @build @staging
+  @mock-api:dl-success @validation-regression @build @staging
   Scenario Outline:  DVLA Driving Licence last name validation test - 44 characters
     Given User enters DVLA data as a <DrivingLicenceSubject>
     And User re-enters last name as <InvalidLastName>
@@ -503,7 +503,7 @@ Feature: DVLA Driving licence CRI Error Validations
       | DrivingLicenceSubjectHappyKenneth |                  | abcdefghijklmnopqrstuvwxyzabcdefghijklm |
 
   @mock-api:dl-success @validation-regression @build @staging
-  Scenario Outline:  DVLA Driving Licence character limit happy path validation test
+  Scenario Outline:  DVLA Driving Licence character limit happy path validation test - first name
     Given User enters DVLA data as a <DrivingLicenceSubject>
     And User re-enters last name as <InvalidLastName>
     And User re-enters first name as <InvalidFirstName>
@@ -513,7 +513,7 @@ Feature: DVLA Driving licence CRI Error Validations
       | DrivingLicenceSubjectHappyKenneth | abcdefghijklmnopqrstuvwxyzabcdefghijklmnopq | abcdefghijklmnopqrstuvwxyzabcdefghijkl |
 
   @mock-api:dl-failed @validation-regression @build @staging
-  Scenario Outline:  DVLA Driving Licence character limit happy path validation test
+  Scenario Outline:  DVLA Driving Licence character limit happy path validation test - given names
     Given User enters DVLA data as a <DrivingLicenceSubject>
     And User re-enters last name as <InvalidLastName>
     And User re-enters first name as <InvalidFirstName>
@@ -526,7 +526,7 @@ Feature: DVLA Driving licence CRI Error Validations
       | DrivingLicenceSubjectHappyKenneth | abcdefghijklmnopqrstuvwxyzabcdefghijklmnopq |                  | abcdefghijklmnopqrstuvwxyzabcdefghijk |
 
   @mock-api:dl-failed @validation-regression @build @staging
-  Scenario Outline:  DVLA Driving Licence character limit happy path validation test
+  Scenario Outline:  DVLA Driving Licence character limit unhappy path validation test
     Given User enters DVLA data as a <DrivingLicenceSubject>
     And User re-enters last name as <InvalidLastName>
     And User re-enters middle names as <InvalidMiddleNames>

--- a/test/browser/pages/DrivingLicencePage.js
+++ b/test/browser/pages/DrivingLicencePage.js
@@ -367,9 +367,10 @@ exports.DrivingLicencePage = class PlaywrightDevPage {
   }
 
   async userReEntersDayOfIssueAsCurrentDateMinus(days) {
-    await this.licenceIssueDay.fill(
-      moment().subtract(days, "days").format("DD")
-    );
+    var subtractedDate = moment().subtract(days, "days");
+    await this.licenceIssueDay.fill(subtractedDate.format("DD"));
+    await this.licenceIssueMonth.fill(subtractedDate.format("MM"));
+    await this.licenceIssueYear.fill(subtractedDate.format("YYYY"));
   }
 
   async userReEntersDayOfIssueAsCurrentDatePlus(days) {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Adding logic to fieldHelper to set new limits for name fields and adding validation checks for combining first and middle names

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-816](https://govukverify.atlassian.net/browse/LIME-816)

## Checklists

### Environment variables or secrets


### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[LIME-816]: https://govukverify.atlassian.net/browse/LIME-816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ