### PR TITLE
LIME-847 updating link for DVA privacy notice

### DIFF
--- a/src/locales/cy/fields.yml
+++ b/src/locales/cy/fields.yml
@@ -113,7 +113,7 @@ consentDVACheckbox:
     <p>I ddarganfod mwy am sut bydd eich manylion trwydded yrru yn cael eu defnyddio, gallwch ddarllen:</p>
     <ul class="govuk-list govuk-list--bullet">
     <li class="govuk-body govuk-!-margin-left-2"><a href="https://signin.account.gov.uk/privacy-notice" class="govuk-link" rel="noopener" target="_blank">hysbysiad preifatrwydd GOV.UK One Login (agor mewn tab newydd)</a></li>
-    <li class="govuk-body govuk-!-margin-left-2"><a href="https://www.infrastructure-ni.gov.uk/sites/default/files/publications/infrastructure/dva-driver-licensing-privacy-notice-may-2023.pdf" class="govuk-link" rel="noopener" target="_blank">hysbysiad preifatrwydd DVA (agor mewn tab newydd)</a></li>
+    <li class="govuk-body govuk-!-margin-left-2"><a href="https://www.infrastructure-ni.gov.uk/publications/gdpr-privacy-notices-dfi-business-areas" class="govuk-link" rel="noopener" target="_blank">hysbysiad preifatrwydd DVA (agor mewn tab newydd)</a></li>
     </ul>
   validation:
     default: "Mae'n rhaid i chi roi eich caniatâd i barhau"

--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -113,7 +113,7 @@ consentDVACheckbox:
     <p>To find out more about how your driving licence details will be used, you can read:</p>
     <ul class="govuk-list govuk-list--bullet">
     <li class="govuk-body govuk-!-margin-left-2"><a href="https://signin.account.gov.uk/privacy-notice" class="govuk-link" rel="noopener" target="_blank" class="govuk-body govuk-!-margin-left-4">the GOV.UK One Login privacy notice (opens in a new tab)</a></li>
-    <li class="govuk-body govuk-!-margin-left-2"><a href="https://www.infrastructure-ni.gov.uk/sites/default/files/publications/infrastructure/dva-driver-licensing-privacy-notice-may-2023.pdf" class="govuk-link" rel="noopener" target="_blank">the DVA privacy notice (opens in a new tab)</a></li>
+    <li class="govuk-body govuk-!-margin-left-2"><a href="https://www.infrastructure-ni.gov.uk/publications/gdpr-privacy-notices-dfi-business-areas" class="govuk-link" rel="noopener" target="_blank">the DVA privacy notice (opens in a new tab)</a></li>
     </ul>
   validation:
     default: "You must give your consent to continue"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Updated the DVA link for privacy notice instead of routing the user to a PDF which had been removed

### Why did it change

To fix the broken link

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-847](https://govukverify.atlassian.net/browse/LIME-847)

## Checklists

### Environment variables or secrets


[LIME-847]: https://govukverify.atlassian.net/browse/LIME-847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ