### PR TITLE
LIME-849 - Fixing DOB/Licence number validation for DVLA

### DIFF
--- a/src/app/drivingLicence/fieldsHelper.js
+++ b/src/app/drivingLicence/fieldsHelper.js
@@ -47,7 +47,12 @@ module.exports = {
     // eslint-disable-next-line no-unused-vars
     const nameShort =
       surname.length >= 5 ? surname.slice(0, 5) : surname.padEnd(5, "9");
+
+    if (!dob) {
+      return false;
+    }
     const splitDate = dob.split("-");
+
     if (firstName) {
       var initialsShort = firstName.slice(0, 1);
       if (middleName) {


### PR DESCRIPTION
### What changed

Bug in fieldshelper.js meant that dob was undefined, causing the FE to crash, fix is to wrap the dob in a nullcheck
