### PR TITLE
LIME-727 Set desiredTaskCount to 2 for all envs to avoid triggering DLOnlyOneTaskCountAlarm in non-prod

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -51,7 +51,7 @@ Mappings:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       fargateCPUsize: "256"
       fargateRAMsize: "512"
-      desiredTaskCount: 1
+      desiredTaskCount: 2
       ga4Enabled: "true"
     build:
       logLevel: "request"
@@ -65,14 +65,14 @@ Mappings:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       fargateCPUsize: "256"
       fargateRAMsize: "512"
-      desiredTaskCount: 1
+      desiredTaskCount: 2
       ga4Enabled: "true"
     integration:
       logLevel: "request"
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       fargateCPUsize: "512"
       fargateRAMsize: "1024"
-      desiredTaskCount: 1
+      desiredTaskCount: 2
       ga4Enabled: "true"
     production:
       logLevel: "request"


### PR DESCRIPTION
## Proposed changes

### What changed

Set desiredTaskCount to 2 for all envs

### Why did it change

To avoid triggering DLOnlyOneTaskCountAlarm in non-prod

### Issue tracking

- [LIME-727](https://govukverify.atlassian.net/browse/LIME-727)


[LIME-727]: https://govukverify.atlassian.net/browse/LIME-727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ