### PR TITLE
LIME-850 DoB, issue date and expiry to only accept 4 digits

### DIFF
--- a/src/app/drivingLicence/controllers/details.js
+++ b/src/app/drivingLicence/controllers/details.js
@@ -3,7 +3,13 @@ const DateControllerMixin = require("hmpo-components").mixins.Date;
 
 const DateController = DateControllerMixin(BaseController);
 
+const logger = require("hmpo-logger").get();
+
 class DrivingLicenceDetailsController extends DateController {
+  _padYear(value, offset) {
+    logger.info("offset value of {} ignored as no padding is applied", offset);
+    return value;
+  }
   async saveValues(req, res, callback) {
     super.saveValues(req, res, () => {
       req.sessionModel.set("showRetryMessage", false);

--- a/src/app/drivingLicence/controllers/details.test.js
+++ b/src/app/drivingLicence/controllers/details.test.js
@@ -35,4 +35,13 @@ describe("details controller", () => {
     const showRetryMessage = req.sessionModel.get("showRetryMessage");
     expect(showRetryMessage).to.equal(false);
   });
+
+  it("should not pad the year field", async () => {
+    var value = "30";
+    var offset = 0;
+
+    var finalYear = await details._padYear(value, offset);
+
+    expect(finalYear).to.equal("30");
+  });
 });

--- a/test/browser/features/English/DVA/DVA.feature
+++ b/test/browser/features/English/DVA/DVA.feature
@@ -157,7 +157,7 @@ Feature: DVA Driving licence CRI Error Validations
 
 #####  DateOfBirthNotReal, DateOfBirthWithSpecialCharacters, NoDateOfBirth #####
   @mock-api:dva-invalidDateOfBirth @validation-regression @build @staging
-  Scenario Outline: DVA Driving Licence Date of birth that are not real or with special characters or no date of birth error validation
+  Scenario Outline: DVA Driving Licence Date of birth that are not real or with special characters or no date of birth error validation or year provided is two digits
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     And DVA user re-enters day of birth as <InvalidDayOfBirth>
     And DVA user re-enters month of birth as <InvalidMonthOfBirth>
@@ -171,6 +171,7 @@ Feature: DVA Driving licence CRI Error Validations
       |DrivingLicenceSubjectHappyBilly|         51      |     71            |         198      |
       |DrivingLicenceSubjectHappyBilly|         @       |     *&            |         19 7     |
       |DrivingLicenceSubjectHappyBilly|                 |                   |                  |
+      |DrivingLicenceSubjectHappyBilly|         05      |     12            |         29       |
 
   @mock-api:dva-invalidDateOfBirth @validation-regression @build @staging
   Scenario Outline: DVA Driving Licence Date of birth in the future error validation
@@ -188,7 +189,7 @@ Feature: DVA Driving licence CRI Error Validations
 
 #####  IssueDateWithAlphaCharacters, IssueDateWithSpecialCharacters, NoIssueDate #####
   @mock-api:dva-invalidIssueDate @validation-regression @build @staging
-  Scenario Outline: DVA Driving Licence Issue date that are not real or with special characters or no issue date error validation
+  Scenario Outline: DVA Driving Licence Issue date that are not real or with special characters or no issue date error validation or year provided is two digits
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     And DVA user re-enters day of issue as <InvalidDayOfIssue>
     And DVA user re-enters month of issue as <InvalidMonthOfIssue>
@@ -202,6 +203,7 @@ Feature: DVA Driving licence CRI Error Validations
       |DrivingLicenceSubjectHappyBilly|         AA      |     BB            |         AABC     |
       |DrivingLicenceSubjectHappyBilly|         &       |     ^%            |         £$ ^     |
       |DrivingLicenceSubjectHappyBilly|                 |                   |                  |
+      |DrivingLicenceSubjectHappyBilly|         05      |     12            |         19       |
 
   @mock-api:dva-invalidIssueDate @validation-regression @build @staging
   Scenario Outline: DVA Driving Licence Issue date in the future error validation
@@ -219,7 +221,7 @@ Feature: DVA Driving licence CRI Error Validations
 
 #####  InvalidValidToDate, ValidToDateWithSpecialCharacters, NoValidToDate  #####
   @mock-api:dva-invalidExpiryDate @validation-regression @build @staging
-  Scenario Outline: DVA Driving Licence Valid to date that are not real or with special characters or no valid to date error validation
+  Scenario Outline: DVA Driving Licence Valid to date that are not real or with special characters or no valid to date error validation or year provided is two digits
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     And User re-enters valid to day as <InvalidValidToDay>
     And User re-enters valid to month as <InvalidValidToMonth>
@@ -233,6 +235,7 @@ Feature: DVA Driving licence CRI Error Validations
       |DrivingLicenceSubjectHappyBilly|         AA      |     BC            |         AABD     |
       |DrivingLicenceSubjectHappyBilly|         !@      |     £$            |         %^ *     |
       |DrivingLicenceSubjectHappyBilly|                 |                   |                  |
+      |DrivingLicenceSubjectHappyBilly|         05      |     12            |         29       |
 
   @mock-api:dva-invalidExpiryDate @validation-regression @build @staging
   Scenario Outline: DVA Driving Licence Valid to date in the past error validation

--- a/test/browser/features/English/DVLA/DVLA.feature
+++ b/test/browser/features/English/DVLA/DVLA.feature
@@ -211,7 +211,7 @@ Feature: DVLA Driving licence CRI Error Validations
 
 #####  DateOfBirthWithSpecialCharacters, DateOfBirthNotReal, NoDateOfBirth #####
   @mock-api:dl-success @validation-regression @build @staging
-  Scenario Outline: DVLA Driving Licence Date of birth that are not real or with special characters or no date of birth error validation
+  Scenario Outline: DVLA Driving Licence Date of birth that are not real or with special characters or no date of birth error validation or year provided is two digits
     Given User enters DVLA data as a <DrivingLicenceSubject>
     And User re-enters day of birth as <InvalidDayOfBirth>
     And User re-enters month of birth as <InvalidMonthOfBirth>
@@ -224,6 +224,7 @@ Feature: DVLA Driving licence CRI Error Validations
       | DrivingLicenceSubject           | InvalidDayOfBirth | InvalidMonthOfBirth | InvalidYearOfBirth |
       | DrivingLicenceSubjectHappyPeter | @                 | *&                  | 19 7               |
       | DrivingLicenceSubjectHappyPeter | 51                | 71                  | 198                |
+      | DrivingLicenceSubjectHappyPeter | 05                | 08                  | 66                 |
 #      DVLA Driving licence with no date of birth scenario is not displaying the expected error message and has been raised as a bug LIME-694
 #      |DrivingLicenceSubjectHappyPeter|                 |                   |                |
 
@@ -243,7 +244,7 @@ Feature: DVLA Driving licence CRI Error Validations
 
 #####  InvalidIssueDate, NoIssueDate #####
   @mock-api:dl-success @validation-regression @build @staging
-  Scenario Outline: DVLA Driving Licence Issue date that are not real or with special characters or no issue date error validation
+  Scenario Outline: DVLA Driving Licence Issue date that are not real or with special characters or no issue date error validation or year provided is two digits
     Given User enters DVLA data as a <DrivingLicenceSubject>
     And User re-enters day of issue as <InvalidDayOfIssue>
     And User re-enters month of issue as <InvalidMonthOfIssue>
@@ -257,6 +258,7 @@ Feature: DVLA Driving licence CRI Error Validations
       | DrivingLicenceSubjectHappyPeter | AA                | BB                  | AABC               |
       | DrivingLicenceSubjectHappyPeter | &                 | ^%                  | £$ ^               |
       | DrivingLicenceSubjectHappyPeter |                   |                     |                    |
+      | DrivingLicenceSubjectHappyPeter | 7                 | 8                   | 18                 |
 
   @mock-api:dl-success @validation-regression @build @staging
   Scenario Outline: DVLA Driving Licence Issue date that is previous days gets through successfully
@@ -313,7 +315,7 @@ Feature: DVLA Driving licence CRI Error Validations
 
 #####  InvalidValidToDate, ValidToDateWithSpecialCharacters, NoValidToDate  #####
   @mock-api:dl-success @validation-regression @build @staging
-  Scenario Outline: DVLA Driving Licence Valid to date that are not real or with special characters or no valid to date error validation
+  Scenario Outline: DVLA Driving Licence Valid to date that are not real or with special characters or no valid to date error validation or year provided is two digits
     Given User enters DVLA data as a <DrivingLicenceSubject>
     And User re-enters valid to day as <InvalidValidToDay>
     And User re-enters valid to month as <InvalidValidToMonth>
@@ -327,6 +329,7 @@ Feature: DVLA Driving licence CRI Error Validations
       | DrivingLicenceSubjectHappyPeter | AA                | BC                  | AABD               |
       | DrivingLicenceSubjectHappyPeter | !@                | £$                  | %^ *               |
       | DrivingLicenceSubjectHappyPeter |                   |                     |                    |
+      | DrivingLicenceSubjectHappyPeter | 5                 | 8                   | 29                 |
 
   @mock-api:dl-success @validation-regression @build @staging
   Scenario Outline: DVLA Driving Licence Valid to date in the past error validation


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

The functionality for dates has been changed so the webform will only accept a four digit year value. If someone tries to input two digits, they will be informed they should enter the value as it appears on their driving licence.

### Why did it change

This was changed due to a bug where users were allowed to enter a two digit expiry date but the logic was assuming it was '19' instead of '20' for the century.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-850](https://govukverify.atlassian.net/browse/LIME-850)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[LIME-850]: https://govukverify.atlassian.net/browse/LIME-850?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ