### PR TITLE
LIME-714 removing prove another way logic

### DIFF
--- a/src/app/drivingLicence/fields.js
+++ b/src/app/drivingLicence/fields.js
@@ -255,11 +255,6 @@ module.exports = {
     validate: ["required"],
     dependent: { field: "issuerDependent", value: "DVLA" }
   },
-  proveAnotherWayRadio: {
-    type: "radios",
-    items: ["proveAnotherWay", "retry"],
-    validate: ["required"]
-  },
   licenceIssuer: {
     type: "radios",
     label: "",

--- a/src/locales/cy/default.yml
+++ b/src/locales/cy/default.yml
@@ -68,9 +68,6 @@ drivingLicence:
   consentDVA: Caniatau DVA i wirio eich manylion trwydded yrru
   consentDVLA: Caniatau DVLA i wirio eich manylion trwydded yrru
 
-prove-another-way:
-  title: Profi pwy ydych chi mewn ffordd arall
-
 licence-issuer:
   title: Pwy wnaeth gyhoeddi eich trwydded yrru y DU?
   content: Gallwch ddod o hyd i hwn yn adran 4c o'ch trwydded yrru. Bydd naill ai'n dweud DVLA (Asiantaeth Trwyddedu Gyrru a Cherbydau) neu DVA (Asiantaeth Gyrrwyr a Cherbydau).

--- a/src/locales/cy/fields.yml
+++ b/src/locales/cy/fields.yml
@@ -133,18 +133,6 @@ consentCheckbox:
   validation:
     default: "Mae'n rhaid i chi roi eich caniatâd i barhau"
 
-proveAnotherWayRadio:
-  label: Beth hoffech chi ei wneud?
-  validation:
-    required: Mae'n rhaid i chi ddewis opsiwn i barhau
-  items:
-    proveAnotherWay:
-      label: Profi pwy ydych chi mewn ffordd arall
-      value: continue
-    retry:
-      label: Ceisiwch roi manylion eich pasbort a phrofi pwy ydych chi gyda chyfrif GOV.UK
-      value: retry
-
 licenceIssuer:
   validation:
     required: Mae'n rhaid i chi ddewis opsiwn i barhau

--- a/src/locales/cy/pages.yml
+++ b/src/locales/cy/pages.yml
@@ -1,10 +1,4 @@
 # title is managed in default.yml
-prove-another-way:
-  title: Profi pwy ydych chi mewn ffordd arall
-  content:
-    - Mae'n rhaid cael pasbort y DU i brofi pwy ydych chi gyda chyfrif GOV.UK. Os nad oes gennych un neu os na allwch gofio eich manylion, gallwch brofi pwy ydych chi mewn ffordd arall.
-    - Efallai y bydd hyn yn cymryd mwy na 10 munud i chi..
-
 licence-issuer:
   title: Pwy wnaeth gyhoeddi eich trwydded yrru y DU?
   content:

--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -68,9 +68,6 @@ drivingLicence:
   consentDVA: Allow DVA to check your driving licence details
   consentDVLA: Allow DVLA to check your driving licence details
 
-prove-another-way:
-  title: Prove your identity another way
-
 licence-issuer:
   title: Who was your UK driving licence issued by?
   content: You can find this in section 4c of your driving licence. It will either say DVLA (Driving and vehicle Licensing Agency) or DVA (Driver and Vehicle Agency).

--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -133,18 +133,6 @@ consentCheckbox:
   validation:
     default: "You must give your consent to continue"
 
-proveAnotherWayRadio:
-  label: What would you like to do?
-  validation:
-    required: You must choose an option to continue
-  items:
-    proveAnotherWay:
-      label: Prove your identity another way
-      value: continue
-    retry:
-      label: Try to enter your driving licence details and prove your identity with a GOV.UK account
-      value: retry
-
 licenceIssuer:
   validation:
     required: You must choose an option to continue

--- a/src/locales/en/pages.yml
+++ b/src/locales/en/pages.yml
@@ -1,10 +1,4 @@
 # title is managed in default.yml
-prove-another-way:
-  title: Prove your identity another way
-  content:
-    - You must have a UK driving licence to prove your identity with a GOV.UK account. If you do not have one or you cannot remember your details, you can prove your identity another way.
-    - This might take you longer than 10 minutes.
-
 licence-issuer:
   title: Who was your UK driving licence issued by?
   content:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Removing any logic referring to prove another way web pages

### Why did it change

To allow for a direct referral back to Core.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-714](https://govukverify.atlassian.net/browse/LIME-714)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[LIME-714]: https://govukverify.atlassian.net/browse/LIME-714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ