### PR TITLE
DFC 464 |  GA4 Implementation Update

### DIFF
--- a/src/views/drivingLicence/details.html
+++ b/src/views/drivingLicence/details.html
@@ -298,7 +298,7 @@ autocomplete: "family-name"
                     statusCode: '200', // Access status code
                     englishPageTitle: '{{translate("pages.details.title")}}',
                     taxonomy_level1: 'CRI', // Access taxonomy level 1
-                    taxonomy_level2: 'details', // Access taxonomy level 2
+                    taxonomy_level2: 'driving licence', // Access taxonomy level 2
                     content_id: '002',
                     logged_in_status: true,
                     dynamic: false

--- a/src/views/drivingLicence/licence-issuer.html
+++ b/src/views/drivingLicence/licence-issuer.html
@@ -8,7 +8,7 @@
 {% from "hmpo-details/macro.njk" import hmpoDetails %}
 
 {% block mainContent %}
-<h1 id="header" data-page="{{hmpoPageKey}}" class="govuk-heading-l">
+<h1 id="header" data-page="{{hmpoPageKey}}" class="govuk-heading-l" rel="licenceIssuer">
     {{ translate("licence-issuer.title") }}
 </h1>
 {% call hmpoForm(ctx, {
@@ -23,10 +23,10 @@ id: "licenceIssuer"
 {% block submitButton %}
     {{ hmpoSubmit(ctx, {id: 'submitButton'}) }}
 
-    {{ govukDetails({
+{{ govukDetails({
         summaryText: translate("pages.licence-issuer.details.summary"),
         text: translate("pages.licence-issuer.details.text")
-    }) }}
+}) }}
 {% endblock %}
 
 {% endcall %}
@@ -44,7 +44,7 @@ id: "licenceIssuer"
                     statusCode: '200', // Access status code
                     englishPageTitle: '{{translate("licence-issuer.title")}}',
                     taxonomy_level1: 'CRI', // Access taxonomy level 1
-                    taxonomy_level2: 'licence-issuer', // Access taxonomy level 2
+                    taxonomy_level2: 'driving licence', // Access taxonomy level 2
                     content_id: '001',
                     logged_in_status: true,
                     dynamic: false

--- a/src/views/errors/error.html
+++ b/src/views/errors/error.html
@@ -25,7 +25,7 @@
                     statusCode: '500', // Access status code
                     englishPageTitle: '{{translate("error.title")}}',
                     taxonomy_level1: 'CRI', // Access taxonomy level 1
-                    taxonomy_level2: 'error', // Access taxonomy level 2
+                    taxonomy_level2: 'driving licence', // Access taxonomy level 2
                     content_id: '003',
                     logged_in_status: true,
                     dynamic: false

--- a/src/views/errors/page-not-found.html
+++ b/src/views/errors/page-not-found.html
@@ -26,7 +26,7 @@
                     statusCode: '404', // Access status code
                     englishPageTitle: '{{translate("pageNotFound.title")}}',
                     taxonomy_level1: 'CRI', // Access taxonomy level 1
-                    taxonomy_level2: 'page-not-found', // Access taxonomy level 2
+                    taxonomy_level2: 'driving licence', // Access taxonomy level 2
                     content_id: '004',
                     logged_in_status: true,
                     dynamic: false

--- a/src/views/errors/session-ended.html
+++ b/src/views/errors/session-ended.html
@@ -22,7 +22,7 @@
                     statusCode: '200', // Access status code
                     englishPageTitle: '{{translate("sessionEnded.title")}}',
                     taxonomy_level1: 'CRI', // Access taxonomy level 1
-                    taxonomy_level2: 'session-ended', // Access taxonomy level 2
+                    taxonomy_level2: 'driving licence', // Access taxonomy level 2
                     content_id: '005',
                     logged_in_status: true,
                     dynamic: false


### PR DESCRIPTION
## Proposed changes

### What changed

<!-- Describe the changes in detail - the "what"-->

- Updated all the  taxonomy level 2 values for the PageViewTracker to "driving licence"

- Refactored the structure of the licence-issuer Nunjucks file to address an issue with the formResponse tracker. The tracker was unable to correctly push the value for the section parameter. As a solution, I added an h1 element with a rel attribute, allowing the formResponse tracker to recognise and retrieve it as the section value.
- Upgrade to latest version of the package- version 0.0.10

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
Fix Bugs / Improve GA4 Implementation 

**How our form trackers get the section value for a form input**
<img width="1034" alt="Screenshot 2024-04-04 at 16 49 10" src="https://github.com/govuk-one-login/ipv-cri-dl-front/assets/148252375/7d921c50-70dc-4b2d-853d-671d4649a9da">

<img width="906" alt="Screenshot 2024-04-04 at 16 49 23" src="https://github.com/govuk-one-login/ipv-cri-dl-front/assets/148252375/a809bcf6-a23a-492a-bf30-c32557db529a">

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [DFC-464](https://govukverify.atlassian.net/browse/DFC-464)
- [DFC-453](https://govukverify.atlassian.net/browse/DFC-453)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[DFC-464]: https://govukverify.atlassian.net/browse/DFC-464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DFC-453]: https://govukverify.atlassian.net/browse/DFC-453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ