### PR TITLE
DFC-640 | GA4| Update taxonomy level1 for pageViewTracker

### DIFF
--- a/src/views/drivingLicence/details.html
+++ b/src/views/drivingLicence/details.html
@@ -297,7 +297,7 @@ autocomplete: "family-name"
                 .trackOnPageLoad({
                     statusCode: '200', // Access status code
                     englishPageTitle: '{{translate("pages.details.title")}}',
-                    taxonomy_level1: 'CRI', // Access taxonomy level 1
+                    taxonomy_level1: 'web cri', // Access taxonomy level 1
                     taxonomy_level2: 'driving licence', // Access taxonomy level 2
                     content_id: '002',
                     logged_in_status: true,

--- a/src/views/drivingLicence/licence-issuer.html
+++ b/src/views/drivingLicence/licence-issuer.html
@@ -43,7 +43,7 @@ id: "licenceIssuer"
                 .trackOnPageLoad({
                     statusCode: '200', // Access status code
                     englishPageTitle: '{{translate("licence-issuer.title")}}',
-                    taxonomy_level1: 'CRI', // Access taxonomy level 1
+                    taxonomy_level1: 'web cri', // Access taxonomy level 1
                     taxonomy_level2: 'driving licence', // Access taxonomy level 2
                     content_id: '001',
                     logged_in_status: true,

--- a/src/views/errors/error.html
+++ b/src/views/errors/error.html
@@ -24,7 +24,7 @@
                 .trackOnPageLoad({
                     statusCode: '500', // Access status code
                     englishPageTitle: '{{translate("error.title")}}',
-                    taxonomy_level1: 'CRI', // Access taxonomy level 1
+                    taxonomy_level1: 'web cri', // Access taxonomy level 1
                     taxonomy_level2: 'driving licence', // Access taxonomy level 2
                     content_id: '003',
                     logged_in_status: true,

--- a/src/views/errors/page-not-found.html
+++ b/src/views/errors/page-not-found.html
@@ -25,7 +25,7 @@
                 .trackOnPageLoad({
                     statusCode: '404', // Access status code
                     englishPageTitle: '{{translate("pageNotFound.title")}}',
-                    taxonomy_level1: 'CRI', // Access taxonomy level 1
+                    taxonomy_level1: 'web cri', // Access taxonomy level 1
                     taxonomy_level2: 'driving licence', // Access taxonomy level 2
                     content_id: '004',
                     logged_in_status: true,

--- a/src/views/errors/session-ended.html
+++ b/src/views/errors/session-ended.html
@@ -21,7 +21,7 @@
                 .trackOnPageLoad({
                     statusCode: '200', // Access status code
                     englishPageTitle: '{{translate("sessionEnded.title")}}',
-                    taxonomy_level1: 'CRI', // Access taxonomy level 1
+                    taxonomy_level1: 'web cri', // Access taxonomy level 1
                     taxonomy_level2: 'driving licence', // Access taxonomy level 2
                     content_id: '005',
                     logged_in_status: true,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

<!-- Describe the changes in detail - the "what"-->

Taxonomy Level 1 value for all pages updated from "cri" to "web cri" as requested by the Data & Analytics team

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

As part of the CI changes following GA4 go live

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

(DFC-640)[https://govukverify.atlassian.net/browse/DFC-640]

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->
