### PR TITLE
IPS-555: Enable canary deployment (stage 2)

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -36,15 +36,6 @@ Parameters:
     Type: String
     Default: "None"
     # Allowed values: See https://docs.aws.amazon.com/codedeploy/latest/userguide/deployment-configurations.html
-  CodeSigningConfigArn:
-    Type: String
-    Description: Asserts that lambdas are signed when deployed.
-    Default: "none"
-  DeploymentStrategy:
-    Description: "Predefined deployment configuration for ECS application"
-    Type: String
-    Default: "None"
-    # Allowed values: See https://docs.aws.amazon.com/codedeploy/latest/userguide/deployment-configurations.html
 
 Conditions:
   IsNotDevelopment: !Or
@@ -408,22 +399,10 @@ Resources:
       EnableECSManagedTags: false
       HealthCheckGracePeriodSeconds: 60
       LaunchType: FARGATE
-      LoadBalancers:
-        - ContainerName: app
-          ContainerPort: 8080
-          TargetGroupArn: !Ref LoadBalancerListenerTargetGroupECS
-      NetworkConfiguration:
-        AwsvpcConfiguration:
-          AssignPublicIp: DISABLED
-          SecurityGroups:
-            - !GetAtt ECSSecurityGroup.GroupId
-          Subnets:
-            - Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnetIdA"
-            - Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnetIdB"
-        # This is an alternative implementation if you want to split across all PrivateSubnets (but don't know how many there are)
-        # Fn::Split:
-        #   [ ",", Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnets" ]
-      TaskDefinition: !Ref ECSServiceTaskDefinition
+      TaskDefinition: !If
+        - UseCanaryDeployment
+        - !Ref AWS::NoValue
+        - !Ref ECSServiceTaskDefinition
       Tags:
         - Key: Name
           Value: !Sub "${AWS::StackName}-ECS"

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -399,6 +399,25 @@ Resources:
       EnableECSManagedTags: false
       HealthCheckGracePeriodSeconds: 60
       LaunchType: FARGATE
+      LoadBalancers: !If
+        - UseCanaryDeployment
+        - !Ref AWS::NoValue
+        - - ContainerName: app
+            ContainerPort: 8080
+            TargetGroupArn: !Ref LoadBalancerListenerTargetGroupECS
+      NetworkConfiguration: !If
+        - UseCanaryDeployment
+        - !Ref AWS::NoValue
+        - AwsvpcConfiguration:
+            AssignPublicIp: DISABLED
+            SecurityGroups:
+              - !GetAtt ECSSecurityGroup.GroupId
+            Subnets:
+              - Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnetIdA"
+              - Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnetIdB"
+          # This is an alternative implementation if you want to split across all PrivateSubnets (but don't know how many there are)
+          # Fn::Split:
+          #   [ ",", Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnets" ]
       TaskDefinition: !If
         - UseCanaryDeployment
         - !Ref AWS::NoValue

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -36,6 +36,15 @@ Parameters:
     Type: String
     Default: "None"
     # Allowed values: See https://docs.aws.amazon.com/codedeploy/latest/userguide/deployment-configurations.html
+  CodeSigningConfigArn:
+    Type: String
+    Description: Asserts that lambdas are signed when deployed.
+    Default: "none"
+  DeploymentStrategy:
+    Description: "Predefined deployment configuration for ECS application"
+    Type: String
+    Default: "None"
+    # Allowed values: See https://docs.aws.amazon.com/codedeploy/latest/userguide/deployment-configurations.html
 
 Conditions:
   IsNotDevelopment: !Or


### PR DESCRIPTION
To be merged after https://github.com/govuk-one-login/ipv-cri-check-hmrc-front/pull/248

### What changed

- Updated TaskDefintion
- Removed NetworkConfiguration and LoadBalancers property from your ECS Service resource. 

### Why did it change

- Second of 2 PRs to enable canary deployments
- To enable canary deployments
- Other config commented out to avoid errors, see step 7: https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3821732161/ECS+-+Canary+Deployments+Migration+Guidance

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [IPS-532](https://govukverify.atlassian.net/browse/IPS-532)
- [IPS-555](https://govukverify.atlassian.net/browse/IPS-555)


### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[IPS-532]: https://govukverify.atlassian.net/browse/IPS-532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IPS-555]: https://govukverify.atlassian.net/browse/IPS-555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ