### PR TITLE
IPS-1123 Use dev-platform action to sign images

### DIFF
--- a/.github/workflows/post-merge-to-build.yml
+++ b/.github/workflows/post-merge-to-build.yml
@@ -41,9 +41,10 @@ jobs:
           password: ${{ secrets.DYNATRACE_PAAS_TOKEN }}
 
       - name: "Push signed image to ECR, updated SAM template with image then upload it to the S3 Artifact Bucket"
-        uses: govuk-one-login/devplatform-upload-action-ecr@v1.2.6
+        uses: govuk-one-login/devplatform-upload-action-ecr@v1.3.0
         with:
           artifact-bucket-name: ${{ secrets.BUILD_ARTIFACT_BUCKET }}
+          container-sign-kms-key-arn: ${{ secrets.BUILD_CONTAINER_SIGN_KMS_KEY }}
           template-file: deploy/template.yaml
           role-to-assume-arn: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
           ecr-repo-name: ${{ secrets.ECR_REPOSITORY }}

--- a/.github/workflows/post-merge-to-dev.yml
+++ b/.github/workflows/post-merge-to-dev.yml
@@ -42,9 +42,10 @@ jobs:
           password: ${{ secrets.DYNATRACE_PAAS_TOKEN }}
 
       - name: "Push signed image to ECR, updated SAM template with image then upload it to the S3 Artifact Bucket"
-        uses: govuk-one-login/devplatform-upload-action-ecr@v1.2.6
+        uses: govuk-one-login/devplatform-upload-action-ecr@v1.3.0
         with:
           artifact-bucket-name: ${{ secrets.DEV_ARTIFACT_BUCKET }}
+          container-sign-kms-key-arn: ${{ secrets.DEV_CONTAINER_SIGN_KMS_KEY }}
           template-file: deploy/template.yaml
           role-to-assume-arn: ${{ secrets.AWS_DL_DEV_ROLE_ARN }}
           ecr-repo-name: ${{ secrets.DEV_ECR_REPOSITORY }}


### PR DESCRIPTION
## Proposed changes

### What changed

Updated workflows to sign the container image

### Why did it change

Container signing is enforced by the canary lambda pipeline version so this change needs to be in place beforehand

### Issue tracking

- [IPS-1123](https://govukverify.atlassian.net/browse/IPS-1123)

### Other considerations

The pipelines need to be updated to include the signing key in conjunction with this change


[IPS-1123]: https://govukverify.atlassian.net/browse/IPS-1123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ