### PR TITLE
Welsh lang copyright wording added

### DIFF
--- a/src/locales/cy/default.yml
+++ b/src/locales/cy/default.yml
@@ -53,6 +53,11 @@ govuk:
         - href: "https://home.account.gov.uk/contact-gov-uk-one-login"
           text: "Cymorth (agor mewn tab newydd)"
           attributes: { target: "_blank", rel:"noreferrer noopener" }
+    copyright:
+      text: "© Hawlfraint y goron"
+    contentLicence:
+      html: 'Mae’r holl gynnwys ar gael o dan <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence-cymraeg/version/3/" rel="licence">Trwydded Llywodraeth Agored v3.0</a>, oni nodir yn wahanol'
+
 drivingLicence:
   title: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru
   serviceNameRequired: true

--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -53,6 +53,10 @@ govuk:
         - href: "https://home.account.gov.uk/contact-gov-uk-one-login"
           text: "Support (opens in new tab)"
           attributes: { target: "_blank", rel:"noreferrer noopener" }
+    contentLicence:
+      html: 'All content is available under the <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated.'
+    copyright:
+      text: "© Crown copyright"
 drivingLicence:
   title: Enter your details exactly as they appear on your UK driving licence
   serviceNameRequired: true

--- a/src/views/errors/error.html
+++ b/src/views/errors/error.html
@@ -34,3 +34,9 @@
     </script>
     {{ super ()}}
 {% endblock %}
+{# generate the specific footer items required for the PYI flows #}
+{% set footerNavItems = translate("govuk.footerNavItems") %}
+
+{% block footer %}
+{{ govukFooter( footerNavItems ) }}
+{% endblock %}

--- a/src/views/errors/page-not-found.html
+++ b/src/views/errors/page-not-found.html
@@ -35,3 +35,9 @@
     </script>
     {{ super ()}}
 {% endblock %}
+{# generate the specific footer items required for the PYI flows #}
+{% set footerNavItems = translate("govuk.footerNavItems") %}
+
+{% block footer %}
+{{ govukFooter( footerNavItems ) }}
+{% endblock %}

--- a/src/views/errors/session-ended.html
+++ b/src/views/errors/session-ended.html
@@ -31,3 +31,9 @@
     </script>
     {{ super ()}}
 {% endblock %}
+{# generate the specific footer items required for the PYI flows #}
+{% set footerNavItems = translate("govuk.footerNavItems") %}
+
+{% block footer %}
+{{ govukFooter( footerNavItems ) }}
+{% endblock %}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

Welsh lang default yml updated to include welsh lang version of copyright text. views/errors/ html files also updated to allow update in default yml to come through on error pages. 

### Why did it change

Previously the Welsh language version of pages included footer text relating to copyright in English. 

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-873](https://govukverify.atlassian.net/browse/LIME-873)

### Other considerations

I have found that no content text is provided for the sessionEnded error page in the pages.yml file in any of the fraud, passport or DL CRIs so the browser literally displays the text ‘_sessionEnded.content_’.  See jira ticket for screenshot. This may require another ticket being generated to provide content text that can be shown on the sessionEnded error pages? 


[LIME-873]: https://govukverify.atlassian.net/browse/LIME-873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ