### PR TITLE
LIME-1169 Set log group retention in days to 30 for all log groups

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,6 +76,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -110,175 +114,204 @@
   "results": {
     ".yarn/releases/yarn-1.22.17.cjs": [
       {
-        "type": "Hex High Entropy String",
+        "type": "Base64 High Entropy String",
         "filename": ".yarn/releases/yarn-1.22.17.cjs",
-        "hashed_secret": "02dea585f59babe05225954c8d1fdec196a1baec",
-        "is_verified": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".yarn/releases/yarn-1.22.17.cjs",
-        "hashed_secret": "07d36c201d5f903272b769508b29de6bfc474556",
-        "is_verified": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".yarn/releases/yarn-1.22.17.cjs",
-        "hashed_secret": "10684db52c27b4692a4ee51ef75a1d5234069c53",
-        "is_verified": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".yarn/releases/yarn-1.22.17.cjs",
-        "hashed_secret": "10bf5f5bab05c99283d3d3cd1c3da4ead81b48c5",
-        "is_verified": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".yarn/releases/yarn-1.22.17.cjs",
-        "hashed_secret": "188736fa0029eec343f4a6f4881ec63ecc7c7e8c",
-        "is_verified": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".yarn/releases/yarn-1.22.17.cjs",
-        "hashed_secret": "2287eee32aafc3bc835fcdd2214bf070725160f9",
-        "is_verified": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".yarn/releases/yarn-1.22.17.cjs",
-        "hashed_secret": "32358b0b40f22e5aa4d70e9d0af6cf156840ee38",
-        "is_verified": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".yarn/releases/yarn-1.22.17.cjs",
-        "hashed_secret": "332e2126e121cf2048b5a1903f864df144047773",
-        "is_verified": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".yarn/releases/yarn-1.22.17.cjs",
-        "hashed_secret": "46798dc6618143b34916eb0e8b3e653b368f7469",
-        "is_verified": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".yarn/releases/yarn-1.22.17.cjs",
-        "hashed_secret": "6c9aafdcceb33bbcfd232f40afdb3298eb2c8b03",
-        "is_verified": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".yarn/releases/yarn-1.22.17.cjs",
-        "hashed_secret": "6eb3665ce1c18c0a5de76163e7604dfa4a103ae7",
-        "is_verified": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".yarn/releases/yarn-1.22.17.cjs",
-        "hashed_secret": "7c9ddb05834fa9e6c06ef9d948eb8e1a73881031",
-        "is_verified": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".yarn/releases/yarn-1.22.17.cjs",
-        "hashed_secret": "9ed5e5eb0104bf6b3aecf69b389c289b3dca8261",
-        "is_verified": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".yarn/releases/yarn-1.22.17.cjs",
-        "hashed_secret": "9ef7320615f9c05bad1ea6ad1365104507871d7f",
-        "is_verified": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".yarn/releases/yarn-1.22.17.cjs",
-        "hashed_secret": "aadcdc8ac4254184c1a90fa9c7cc0e8a7dad2e25",
-        "is_verified": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".yarn/releases/yarn-1.22.17.cjs",
-        "hashed_secret": "b1a741d28b1d949ef6184bac2f63e97782793c11",
-        "is_verified": false
+        "hashed_secret": "fd8201493aad9512bb25129219813806e68b2c51",
+        "is_verified": false,
+        "line_number": 79187
       },
       {
         "type": "Secret Keyword",
         "filename": ".yarn/releases/yarn-1.22.17.cjs",
         "hashed_secret": "c218e39efa2e1aae69f39d2054528369ce1e1f46",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 82919
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".yarn/releases/yarn-1.22.17.cjs",
+        "hashed_secret": "b1a741d28b1d949ef6184bac2f63e97782793c11",
+        "is_verified": false,
+        "line_number": 114788
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".yarn/releases/yarn-1.22.17.cjs",
+        "hashed_secret": "6eb3665ce1c18c0a5de76163e7604dfa4a103ae7",
+        "is_verified": false,
+        "line_number": 137804
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".yarn/releases/yarn-1.22.17.cjs",
+        "hashed_secret": "9ef7320615f9c05bad1ea6ad1365104507871d7f",
+        "is_verified": false,
+        "line_number": 137806
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".yarn/releases/yarn-1.22.17.cjs",
+        "hashed_secret": "2287eee32aafc3bc835fcdd2214bf070725160f9",
+        "is_verified": false,
+        "line_number": 137820
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".yarn/releases/yarn-1.22.17.cjs",
-        "hashed_secret": "de3227cfb3b4dcdee04c35b442308cbc451d7424",
-        "is_verified": false
+        "hashed_secret": "10684db52c27b4692a4ee51ef75a1d5234069c53",
+        "is_verified": false,
+        "line_number": 145781
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".yarn/releases/yarn-1.22.17.cjs",
-        "hashed_secret": "df4bff4de4289a6c92aea9d5f068158c89d4ae4b",
-        "is_verified": false
+        "hashed_secret": "7c9ddb05834fa9e6c06ef9d948eb8e1a73881031",
+        "is_verified": false,
+        "line_number": 145782
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".yarn/releases/yarn-1.22.17.cjs",
+        "hashed_secret": "02dea585f59babe05225954c8d1fdec196a1baec",
+        "is_verified": false,
+        "line_number": 145798
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".yarn/releases/yarn-1.22.17.cjs",
+        "hashed_secret": "07d36c201d5f903272b769508b29de6bfc474556",
+        "is_verified": false,
+        "line_number": 145799
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".yarn/releases/yarn-1.22.17.cjs",
         "hashed_secret": "f6de6313ace4093d98c0aea3ddb1a7a733b058e6",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 145815
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".yarn/releases/yarn-1.22.17.cjs",
+        "hashed_secret": "332e2126e121cf2048b5a1903f864df144047773",
+        "is_verified": false,
+        "line_number": 145816
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".yarn/releases/yarn-1.22.17.cjs",
+        "hashed_secret": "6c9aafdcceb33bbcfd232f40afdb3298eb2c8b03",
+        "is_verified": false,
+        "line_number": 145832
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".yarn/releases/yarn-1.22.17.cjs",
         "hashed_secret": "f8692127a363c0b90301c1f9b9713a130eb23685",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 145833
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".yarn/releases/yarn-1.22.17.cjs",
+        "hashed_secret": "32358b0b40f22e5aa4d70e9d0af6cf156840ee38",
+        "is_verified": false,
+        "line_number": 145849
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".yarn/releases/yarn-1.22.17.cjs",
+        "hashed_secret": "46798dc6618143b34916eb0e8b3e653b368f7469",
+        "is_verified": false,
+        "line_number": 145850
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".yarn/releases/yarn-1.22.17.cjs",
+        "hashed_secret": "188736fa0029eec343f4a6f4881ec63ecc7c7e8c",
+        "is_verified": false,
+        "line_number": 145864
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".yarn/releases/yarn-1.22.17.cjs",
+        "hashed_secret": "9ed5e5eb0104bf6b3aecf69b389c289b3dca8261",
+        "is_verified": false,
+        "line_number": 145874
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".yarn/releases/yarn-1.22.17.cjs",
+        "hashed_secret": "de3227cfb3b4dcdee04c35b442308cbc451d7424",
+        "is_verified": false,
+        "line_number": 145875
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".yarn/releases/yarn-1.22.17.cjs",
+        "hashed_secret": "aadcdc8ac4254184c1a90fa9c7cc0e8a7dad2e25",
+        "is_verified": false,
+        "line_number": 145889
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".yarn/releases/yarn-1.22.17.cjs",
         "hashed_secret": "fd193a67b4b1b180176f242ae3b8771e2c9fe3f9",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 145893
       },
       {
-        "type": "Base64 High Entropy String",
+        "type": "Hex High Entropy String",
         "filename": ".yarn/releases/yarn-1.22.17.cjs",
-        "hashed_secret": "fd8201493aad9512bb25129219813806e68b2c51",
-        "is_verified": false
+        "hashed_secret": "10bf5f5bab05c99283d3d3cd1c3da4ead81b48c5",
+        "is_verified": false,
+        "line_number": 145899
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".yarn/releases/yarn-1.22.17.cjs",
+        "hashed_secret": "df4bff4de4289a6c92aea9d5f068158c89d4ae4b",
+        "is_verified": false,
+        "line_number": 145900
       }
     ],
     "deploy/template.yaml": [
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
-        "hashed_secret": "42af5cf9fcf4f09147c032a0fb4877f5cf626bbc",
-        "is_verified": false
+        "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
+        "is_verified": false,
+        "line_number": 72
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
-        "is_verified": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "deploy/template.yaml",
-        "hashed_secret": "7584a31168b8e8f62d9b84b7b95d239b99fad815",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 108
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 589
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
-        "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
-        "is_verified": false
+        "hashed_secret": "42af5cf9fcf4f09147c032a0fb4877f5cf626bbc",
+        "is_verified": false,
+        "line_number": 590
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "deploy/template.yaml",
+        "hashed_secret": "7584a31168b8e8f62d9b84b7b95d239b99fad815",
+        "is_verified": false,
+        "line_number": 592
       }
     ]
-  }
+  },
+  "generated_at": "2024-10-04T13:58:09Z"
 }

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -40,6 +40,10 @@ Parameters:
     Type: String
     Default: "None"
     # Allowed values: See https://docs.aws.amazon.com/codedeploy/latest/userguide/deployment-configurations.html
+  LogGroupRetentionInDays:
+    Description: "Retention for all log groups"
+    Type: Number
+    Default: "30"
 
 Conditions:
   IsNotDevelopment: !Or
@@ -445,7 +449,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/ecs/${AWS::StackName}-DrivingPermitFront-ECS
-      RetentionInDays: 14
+      RetentionInDays: !Ref LogGroupRetentionInDays
 
   ECSAccessLogsGroupSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
@@ -727,6 +731,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-DrivingPermitFront-API-GW-AccessLogs
+      RetentionInDays: !Ref LogGroupRetentionInDays
 
   APIGWAccessLogsGroupSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter


### PR DESCRIPTION
## Proposed changes

### What changed

Ensure log groups are all set to 30 days retention

### Why did it change

To ensure log groups do not have extended retention lengths

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1169](https://govukverify.atlassian.net/browse/LIME-1169)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1169]: https://govukverify.atlassian.net/browse/LIME-1169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ