### PR TITLE
LIME-1299: Added Welsh Lang Tests for DVLA and DVA Footer Links

### DIFF
--- a/test/browser/features/Welsh/DVA/WelshDVA.feature
+++ b/test/browser/features/Welsh/DVA/WelshDVA.feature
@@ -19,6 +19,16 @@ Feature: DVA Driving licence CRI Error Validations
     Given I view the beta banner
     And the beta banner reads Mae hwn yn wasanaeth newydd – bydd eich adborth (agor mewn tab newydd) yn ein helpu i'w wella.
 
+  @mock-api:dva-WelshBetaBanner @language-regression
+  Scenario: Footer Links and Text
+    Given I see the accessibility statement link Datganiad hygyrchedd
+    And I see the cookies link Cwcis
+    And I see the terms and conditions link Telerau ac amodau
+    And I see the privacy notice link Hysbysiad preifatrwydd
+    And I see the support link Cymorth (agor mewn tab newydd)
+    And I see the OLG link Trwydded Llywodraeth Agored v3.0
+    And I see the crown copyright link © Hawlfraint y goron
+
   @mock-api:dva-NameFiled @language-regression
   Scenario: DVA Name fields
     Given I can see the lastname as Enw olaf

--- a/test/browser/features/Welsh/DVLA/WelshDVLA.feature
+++ b/test/browser/features/Welsh/DVLA/WelshDVLA.feature
@@ -19,6 +19,16 @@ Feature: DVLA Driving licence CRI Error Validations
     Given I view the beta banner
     And the beta banner reads Mae hwn yn wasanaeth newydd – bydd eich adborth (agor mewn tab newydd) yn ein helpu i'w wella.
 
+  @mock-api:dvla-WelshBetaBanner @language-regression
+  Scenario: Footer Links and Text
+    Given I see the accessibility statement link Datganiad hygyrchedd
+    And I see the cookies link Cwcis
+    And I see the terms and conditions link Telerau ac amodau
+    And I see the privacy notice link Hysbysiad preifatrwydd
+    And I see the support link Cymorth (agor mewn tab newydd)
+    And I see the OLG link Trwydded Llywodraeth Agored v3.0
+    And I see the crown copyright link © Hawlfraint y goron
+
   @mock-api:dvla-NameField @language-regression
   Scenario: DVLA Name fields
     Given I can see the lastname as Enw olaf

--- a/test/browser/pages/DrivingLicencePage.js
+++ b/test/browser/pages/DrivingLicencePage.js
@@ -147,6 +147,34 @@ exports.DrivingLicencePage = class PlaywrightDevPage {
 
     this.betaBanner = this.page.locator("xpath=/html/body/div[2]/div/p/strong");
 
+    this.footerAccessibilityStatementText = this.page.locator(
+      "xpath=//html/body/footer/div/div/div[1]/ul/li[1]/a"
+    );
+
+    this.footerCookieText = this.page.locator(
+      "xpath=//html/body/footer/div/div/div[1]/ul/li[2]/a"
+    );
+
+    this.footerTermsAndConditionsText = this.page.locator(
+      "xpath=//html/body/footer/div/div/div[1]/ul/li[3]/a"
+    );
+
+    this.footerPrivacyNoticeText = this.page.locator(
+      "xpath=//html/body/footer/div/div/div[1]/ul/li[4]/a"
+    );
+
+    this.footerSupportText = this.page.locator(
+      "xpath=//html/body/footer/div/div/div[1]/ul/li[5]/a"
+    );
+
+    this.footerOpenGovernmentLicenceText = this.page.locator(
+      "xpath=//html/body/footer/div/div/div[1]/span/a"
+    );
+
+    this.footerCrownCopyrightText = this.page.locator(
+      "xpath=//html/body/footer/div/div/div[2]/a"
+    );
+
     this.lastNameLabel = this.page.locator('xpath=//*[@id="surname-label"]');
 
     this.givenNameLegend = this.page.locator(
@@ -620,6 +648,66 @@ exports.DrivingLicencePage = class PlaywrightDevPage {
     expect(await this.isCurrentPage()).to.be.true;
     await expect(await this.betaBannerReads.textContent()).to.contains(
       assertBetaBannerText
+    );
+  }
+
+  async assertFooterAccessibilityStatementText(
+    assertFooterAccessibilityStatementText
+  ) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(await this.isCurrentPage()).to.be.true;
+    await expect(
+      await this.footerAccessibilityStatementText.textContent()
+    ).to.contains(assertFooterAccessibilityStatementText);
+  }
+
+  async assertFooterCookieText(assertFooterCookieText) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(await this.isCurrentPage()).to.be.true;
+    await expect(await this.footerCookieText.textContent()).to.contains(
+      assertFooterCookieText
+    );
+  }
+
+  async assertFooterTermsAndConditonsText(assertFooterTermsAndConditonsText) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(await this.isCurrentPage()).to.be.true;
+    await expect(
+      await this.footerTermsAndConditionsText.textContent()
+    ).to.contains(assertFooterTermsAndConditonsText);
+  }
+
+  async assertFooterPrivacyNoticeText(assertFooterPrivacyNoticeText) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(await this.isCurrentPage()).to.be.true;
+    await expect(await this.footerPrivacyNoticeText.textContent()).to.contains(
+      assertFooterPrivacyNoticeText
+    );
+  }
+
+  async assertFooterSupportText(assertFooterSupportText) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(await this.isCurrentPage()).to.be.true;
+    await expect(await this.footerSupportText.textContent()).to.contains(
+      assertFooterSupportText
+    );
+  }
+
+  async assertFooterOpenGovernmentLicenceText(
+    assertFooterOpenGovernmentLicenceText
+  ) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(await this.isCurrentPage()).to.be.true;
+    await expect(
+      await this.footerOpenGovernmentLicenceText.textContent()
+    ).to.contains(assertFooterOpenGovernmentLicenceText);
+  }
+
+  async assertFooterCrownCopyrightText(assertFooterCrownCopyrightText) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(await this.isCurrentPage()).to.be.true;
+    await expect(await this.footerCrownCopyrightText.textContent()).to.contains(
+      assertFooterCrownCopyrightText
     );
   }
 

--- a/test/browser/step_definitions/DrivingLicenceStepDefs.js
+++ b/test/browser/step_definitions/DrivingLicenceStepDefs.js
@@ -601,6 +601,66 @@ Then(/^the beta banner reads (.*)$/, async function (betaBannerText) {
   await drivingLicencePage.assertBetaBannerText(betaBannerText);
 });
 
+Then(
+  /^I see the accessibility statement link (.*)$/,
+  async function (footerAccessibilityStatementText) {
+    const drivingLicencePage = new DrivingLicencePage(this.page);
+    await drivingLicencePage.assertFooterAccessibilityStatementText(
+      footerAccessibilityStatementText
+    );
+  }
+);
+
+Then(/^I see the cookies link (.*)$/, async function (footerCookieText) {
+  const drivingLicencePage = new DrivingLicencePage(this.page);
+  await drivingLicencePage.assertFooterCookieText(footerCookieText);
+});
+
+Then(
+  /^I see the terms and conditions link (.*)$/,
+  async function (footerTermsAndConditionsText) {
+    const drivingLicencePage = new DrivingLicencePage(this.page);
+    await drivingLicencePage.assertFooterTermsAndConditonsText(
+      footerTermsAndConditionsText
+    );
+  }
+);
+
+Then(
+  /^I see the privacy notice link (.*)$/,
+  async function (footerPrivacyNoticeText) {
+    const drivingLicencePage = new DrivingLicencePage(this.page);
+    await drivingLicencePage.assertFooterPrivacyNoticeText(
+      footerPrivacyNoticeText
+    );
+  }
+);
+
+Then(/^I see the support link (.*)$/, async function (footerSupportText) {
+  const drivingLicencePage = new DrivingLicencePage(this.page);
+  await drivingLicencePage.assertFooterSupportText(footerSupportText);
+});
+
+Then(
+  /^I see the OLG link (.*)$/,
+  async function (footerOpenGovernmentLicenceText) {
+    const drivingLicencePage = new DrivingLicencePage(this.page);
+    await drivingLicencePage.assertFooterOpenGovernmentLicenceText(
+      footerOpenGovernmentLicenceText
+    );
+  }
+);
+
+Then(
+  /^I see the crown copyright link (.*)$/,
+  async function (footerCrownCopyrightText) {
+    const drivingLicencePage = new DrivingLicencePage(this.page);
+    await drivingLicencePage.assertFooterCrownCopyrightText(
+      footerCrownCopyrightText
+    );
+  }
+);
+
 Then(/^I can see the lastname as (.*)$/, async function (dvlaLastName) {
   const drivingLicencePage = new DrivingLicencePage(this.page);
   await drivingLicencePage.assertLastName(dvlaLastName);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-1299] PR Title` -->

## Proposed changes

### What changed

Added new Tests to check the Footer Links when on the DVLA and DVA start pages show correctly in Welsh Language

### Why did it change

Following changes to [LIME-873](https://govukverify.atlassian.net/browse/LIME-873) 

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1299](https://govukverify.atlassian.net/browse/LIME-1299)

### Other considerations

All FE Tests passed locally in Dev:
![image](https://github.com/user-attachments/assets/f54535d2-fdae-4c82-aaab-8e98ce5c2080)



[LIME-1299]: https://govukverify.atlassian.net/browse/LIME-1299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIME-873]: https://govukverify.atlassian.net/browse/LIME-873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIME-1299]: https://govukverify.atlassian.net/browse/LIME-1299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ