### PR TITLE
LIME-1208 - Align DL F.E scaling with HMRC KBV F.E

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -288,30 +288,30 @@
         "filename": "deploy/template.yaml",
         "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
         "is_verified": false,
-        "line_number": 108
+        "line_number": 105
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
         "is_verified": false,
-        "line_number": 589
+        "line_number": 587
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "42af5cf9fcf4f09147c032a0fb4877f5cf626bbc",
         "is_verified": false,
-        "line_number": 590
+        "line_number": 588
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "7584a31168b8e8f62d9b84b7b95d239b99fad815",
         "is_verified": false,
-        "line_number": 592
+        "line_number": 590
       }
     ]
   },
-  "generated_at": "2024-10-04T13:58:09Z"
+  "generated_at": "2024-10-18T14:26:35Z"
 }

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -72,7 +72,6 @@ Mappings:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       fargateCPUsize: "256"
       fargateRAMsize: "512"
-      desiredTaskCount: 2
       ga4Disabled: "false"
       uaDisabled: "false"
       languageToggleDisabled: "false"
@@ -81,7 +80,6 @@ Mappings:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       fargateCPUsize: "1024"
       fargateRAMsize: "2048"
-      desiredTaskCount: 2
       ga4Disabled: "false"
       uaDisabled: "false"
       languageToggleDisabled: "false"
@@ -99,7 +97,6 @@ Mappings:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       fargateCPUsize: "512"
       fargateRAMsize: "1024"
-      desiredTaskCount: 2
       ga4Disabled: "false"
       uaDisabled: "false"
       languageToggleDisabled: "false"
@@ -108,7 +105,6 @@ Mappings:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
       fargateCPUsize: "1024"
       fargateRAMsize: "2048"
-      desiredTaskCount: 2
       ga4Disabled: "false"
       uaDisabled: "false"
       languageToggleDisabled: "false"
@@ -245,6 +241,9 @@ Resources:
       HealthCheckEnabled: TRUE
       HealthCheckProtocol: HTTP
       HealthCheckPath: /healthcheck
+      HealthCheckTimeoutSeconds: 2
+      HealthCheckIntervalSeconds: 5
+      HealthyThresholdCount: 2
       Matcher:
         HttpCode: 200
       Port: 80
@@ -403,10 +402,6 @@ Resources:
           - UseCanaryDeployment
           - CODE_DEPLOY
           - ECS
-      DesiredCount: !FindInMap
-        - EnvironmentConfiguration
-        - !Ref "Environment"
-        - desiredTaskCount
       EnableECSManagedTags: false
       HealthCheckGracePeriodSeconds: !If
         - UseCanaryDeployment
@@ -744,143 +739,6 @@ Resources:
       FilterPattern: ""
       LogGroupName: !Sub "/aws/apigateway/${AWS::StackName}-DrivingPermitFront-API-GW-AccessLogs"
 
-  # ECS Autoscaling
-  # The number of pods will increase when the configured CPU utilization is breached for more than 3 minutes.
-  # Scaling down will occur after 15 minutes of 90% utilization of the configured CPU utilization.
-
-  ECSAutoScalingTarget:
-    Condition: IsPerformance
-    Type: AWS::ApplicationAutoScaling::ScalableTarget
-    Properties:
-      MaxCapacity: 60
-      MinCapacity: 2
-      ResourceId: !Join
-        - "/"
-        - - "service"
-          - !Ref DrivingPermitFrontEcsCluster
-          - !GetAtt DrivingPermitFrontEcsService.Name
-      RoleARN: !Sub "arn:aws:iam::${AWS::AccountId}:role/aws-service-role/ecs.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_ECSService"
-      ScalableDimension: ecs:service:DesiredCount
-      ServiceNamespace: ecs
-
-  ECSAutoScalingPolicy:
-    Condition: IsPerformance
-    DependsOn: ECSAutoScalingTarget
-    Type: AWS::ApplicationAutoScaling::ScalingPolicy
-    Properties:
-      PolicyName: ECSAutoScalingPolicy
-      PolicyType: TargetTrackingScaling
-      ResourceId: !Join
-        - "/"
-        - - "service"
-          - !Ref DrivingPermitFrontEcsCluster
-          - !GetAtt DrivingPermitFrontEcsService.Name
-      ScalableDimension: ecs:service:DesiredCount
-      ServiceNamespace: ecs
-      TargetTrackingScalingPolicyConfiguration:
-        PredefinedMetricSpecification:
-          PredefinedMetricType: ECSServiceAverageCPUUtilization
-        TargetValue: 60
-        ScaleInCooldown: 420
-        ScaleOutCooldown: 60
-
-  StepScaleInPolicy:
-    Condition: IsPerformance
-    DependsOn: ECSAutoScalingTarget
-    Type: AWS::ApplicationAutoScaling::ScalingPolicy
-    Properties:
-      PolicyName: StepScalingInPolicy
-      PolicyType: StepScaling
-      ResourceId: !Join
-        - '/'
-        - - "service"
-          - !Ref DrivingPermitFrontEcsCluster
-          - !GetAtt DrivingPermitFrontEcsService.Name
-      ScalableDimension: ecs:service:DesiredCount
-      ServiceNamespace: ecs
-      StepScalingPolicyConfiguration:
-        AdjustmentType: PercentChangeInCapacity
-        Cooldown: 420
-        StepAdjustments:
-          - MetricIntervalUpperBound: -40
-            ScalingAdjustment: -50
-
-  StepScaleOutPolicy:
-    Condition: IsPerformance
-    DependsOn: ECSAutoScalingTarget
-    Type: AWS::ApplicationAutoScaling::ScalingPolicy
-    Properties:
-      PolicyName: StepScalingOutPolicy
-      PolicyType: StepScaling
-      ResourceId: !Join
-        - '/'
-        - - "service"
-          - !Ref DrivingPermitFrontEcsCluster
-          - !GetAtt DrivingPermitFrontEcsService.Name
-      ScalableDimension: ecs:service:DesiredCount
-      ServiceNamespace: ecs
-      StepScalingPolicyConfiguration:
-        AdjustmentType: PercentChangeInCapacity
-        Cooldown: 120
-        MinAdjustmentMagnitude: 5
-        StepAdjustments:
-          - MetricIntervalLowerBound: 20
-            MetricIntervalUpperBound: 30
-            ScalingAdjustment: 200
-          - MetricIntervalLowerBound: 30
-            MetricIntervalUpperBound: 35
-            ScalingAdjustment: 300
-          - MetricIntervalLowerBound: 35
-            ScalingAdjustment: 500
-
-  StepScaleOutAlarm:
-    Condition: IsPerformance
-    DependsOn: ECSAutoScalingTarget
-    Type: AWS::CloudWatch::Alarm
-    Properties:
-      ActionsEnabled: true
-      AlarmActions:
-        - !Ref StepScaleOutPolicy
-      AlarmDescription: "DrivingPermitFrontClusterOver60PercentCPU"
-      ComparisonOperator: "GreaterThanThreshold"
-      DatapointsToAlarm: "2"
-      Dimensions:
-        - Name: ClusterName
-          Value: !Ref DrivingPermitFrontEcsCluster
-        - Name: ServiceName
-          Value: !GetAtt DrivingPermitFrontEcsService.Name
-      Unit: "Percent"
-      EvaluationPeriods: "2"
-      MetricName: "CPUUtilization"
-      Namespace: "AWS/ECS"
-      Statistic: "Average"
-      Period: "60"
-      Threshold: "60"
-
-  StepScaleInAlarm:
-    Condition: IsPerformance
-    DependsOn: ECSAutoScalingTarget
-    Type: AWS::CloudWatch::Alarm
-    Properties:
-      ActionsEnabled: true
-      AlarmActions:
-        - !Ref StepScaleInPolicy
-      AlarmDescription: "DrivingPermitFrontClusterUnder60PercentCPU"
-      ComparisonOperator: "LessThanThreshold"
-      DatapointsToAlarm: "5"
-      Dimensions:
-        - Name: ClusterName
-          Value: !Ref DrivingPermitFrontEcsCluster
-        - Name: ServiceName
-          Value: !GetAtt DrivingPermitFrontEcsService.Name
-      Unit: "Percent"
-      EvaluationPeriods: "5"
-      MetricName: "CPUUtilization"
-      Namespace: "AWS/ECS"
-      Statistic: "Average"
-      Period: "60"
-      Threshold: "60"
-
   DrivingPermitFrontSessionsTable:
     Type: AWS::DynamoDB::Table
     Properties:
@@ -900,6 +758,144 @@ Resources:
         # checkov:skip=CKV_AWS_119: Implement Customer Managed Keys in PYIC-1391
         SSEEnabled: true
         SSEType: KMS
+
+  # ECS Autoscaling
+  ECSAutoScalingTarget:
+    Condition: IsPerformance
+    Type: AWS::ApplicationAutoScaling::ScalableTarget
+    Properties:
+      MinCapacity: 4
+      MaxCapacity: 60
+      ResourceId: !Join
+        - "/"
+        - - "service"
+          - !Ref DrivingPermitFrontEcsCluster
+          - !GetAtt DrivingPermitFrontEcsService.Name
+      RoleARN: !Sub "arn:aws:iam::${AWS::AccountId}:role/aws-service-role/ecs.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_ECSService"
+      ScalableDimension: ecs:service:DesiredCount
+      ServiceNamespace: ecs
+
+  EcsStepScaleOutPolicy:
+    Condition: IsPerformance
+    DependsOn: ECSAutoScalingTarget
+    Type: AWS::ApplicationAutoScaling::ScalingPolicy
+    Properties:
+      PolicyName: EcsStepScalingOutPolicy
+      PolicyType: StepScaling
+      ResourceId: !Join
+        - "/"
+        - - "service"
+          - !Ref DrivingPermitFrontEcsCluster
+          - !GetAtt DrivingPermitFrontEcsService.Name
+      ScalableDimension: ecs:service:DesiredCount
+      ServiceNamespace: ecs
+      StepScalingPolicyConfiguration:
+        AdjustmentType: PercentChangeInCapacity
+        Cooldown:
+          180 # The policy will continue to respond to additional alarm breaches,
+          # even while a scaling activity is in progress. This means Application
+          # Auto Scaling will evaluate all alarm breaches as they occur.
+          # A cooldown period is used to protect against over-scaling due to
+        # multiple alarm breaches occurring in rapid succession.
+        MinAdjustmentMagnitude: 1
+        StepAdjustments:
+          - MetricIntervalUpperBound: 0 # 60%
+            ScalingAdjustment: 100 # Scale by 100% of containers if the metric is breached
+            # with <60% utilisation
+          - MetricIntervalLowerBound: 0 # 60%
+            MetricIntervalUpperBound: 30 # 90%
+            ScalingAdjustment: 200 # Scale by 200% of containers if the metric is breached
+            # with 80-90% utilisation
+          - MetricIntervalLowerBound: 30 # 90%
+            MetricIntervalUpperBound: 35 # 95%
+            ScalingAdjustment: 300 # Scale by 300% of containers if the metric is breached
+            # with 90-95% utilisation
+          - MetricIntervalLowerBound: 35 # 95%
+            ScalingAdjustment:
+              500 # Scale by 500% of containers if the metric is breached
+              # with >95% utilisation
+            # Note: CPU can scale greater than 100% in a burst mode
+            # on Fargate, so leave the upper bound open
+
+  EcsStepScaleInPolicy:
+    Condition: IsPerformance
+    DependsOn: ECSAutoScalingTarget
+    Type: AWS::ApplicationAutoScaling::ScalingPolicy
+    Properties:
+      PolicyName: EcsStepScalingInPolicy
+      PolicyType: StepScaling
+      ResourceId: !Join
+        - "/"
+        - - "service"
+          - !Ref DrivingPermitFrontEcsCluster
+          - !GetAtt DrivingPermitFrontEcsService.Name
+      ScalableDimension: ecs:service:DesiredCount
+      ServiceNamespace: ecs
+      StepScalingPolicyConfiguration:
+        AdjustmentType: PercentChangeInCapacity
+        Cooldown:
+          180 # The policy will continue to respond to additional alarm breaches,
+          # even while a scaling activity is in progress. This means Application
+          # Auto Scaling will evaluate all alarm breaches as they occur.
+          # A cooldown period is used to protect against under-scaling due to
+        # multiple alarm breaches occurring in rapid succession.
+        StepAdjustments:
+          - MetricIntervalUpperBound: -15 # 5%
+            ScalingAdjustment: -90 # Scale down by 90% of containers if the metric is breached
+            # with <5% utilisation
+          - MetricIntervalLowerBound: -15 # 5%
+            MetricIntervalUpperBound: 0 # 20%
+            ScalingAdjustment:
+              -50 # Scale down 50% of containers if the metric is breached
+            # with <20% utilisation
+
+  EcsStepScaleOutAlarm:
+    Condition: IsPerformance
+    DependsOn: ECSAutoScalingTarget
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !Ref EcsStepScaleOutPolicy
+      AlarmDescription: "EcsClusterOver60PercentCPU"
+      ComparisonOperator: "GreaterThanThreshold"
+      DatapointsToAlarm: "1"
+      Dimensions:
+        - Name: ClusterName
+          Value: !Ref DrivingPermitFrontEcsCluster
+        - Name: ServiceName
+          Value: !GetAtt DrivingPermitFrontEcsService.Name
+      Unit: "Percent"
+      EvaluationPeriods: "1"
+      MetricName: "CPUUtilization"
+      Namespace: "AWS/ECS"
+      Statistic: "Average"
+      Period: "60"
+      Threshold: "60"
+
+  EcsStepScaleInAlarm:
+    Condition: IsPerformance
+    DependsOn: ECSAutoScalingTarget
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !Ref EcsStepScaleInPolicy
+      AlarmDescription: "EcsClusterUnder60PercentCPU"
+      ComparisonOperator: "LessThanThreshold"
+      DatapointsToAlarm: "5"
+      Dimensions:
+        - Name: ClusterName
+          Value: !Ref DrivingPermitFrontEcsCluster
+        - Name: ServiceName
+          Value: !GetAtt DrivingPermitFrontEcsService.Name
+      Unit: "Percent"
+      EvaluationPeriods: "5"
+      MetricName: "CPUUtilization"
+      Namespace: "AWS/ECS"
+      Statistic: "Average"
+      Period: "60"
+      Threshold: "20"
 
   ####################################################################
   #                                                                  #


### PR DESCRIPTION
## Proposed changes

### What changed

Align DL F.E scaling with HMRC KBV F.E with MinCapacity at 4 

### Why did it change

Preparation for a new performance test to establish the current performance baseline.

MinCapacity 4 aimed at handling large initial burst traffic from 0% load

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1208](https://govukverify.atlassian.net/browse/LIME-1208)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1208]: https://govukverify.atlassian.net/browse/LIME-1208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ