### PR TITLE
LIME-1368 Welsh translation added for consent screen

### DIFF
--- a/src/locales/cy/pages.yml
+++ b/src/locales/cy/pages.yml
@@ -26,10 +26,10 @@ check-your-details:
   postcode: Cod post
 
 consent:
-  title: We need to check your driving licence details
-  titleDVA: We need to check your driving licence details with the DVA
-  checkDVLA: We need to check the details you provided on your driving licence with the DVLA.
-  checkDVA: We need to check the details you provided on your driving licence with the DVA.
+  title: Rydym angen gwirio manylion eich trwydded yrru
+  titleDVA: Rydym angen gwirio manylion eich trwydded yrru gyda'r DVA
+  checkDVLA: Rydym angen gwirio'r manylion a ddarparwyd gennych ar eich trwydded yrru gyda'r DVLA.
+  checkDVA: Rydym angen gwirio'r manylion a ddarparwyd gennych ar eich trwydded yrru gyda'r DVA.
 
 error:
   title: Mae'n ddrwg gennym, mae problem


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

Welsh translation added to welsh yaml for consent screen 

### Why did it change

To provide welsh translation for consent screen 

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1368](https://govukverify.atlassian.net/browse/LIME-1368
<img width="1728" alt="Screenshot 2024-11-18 at 10 13 14" src="https://github.com/user-attachments/assets/aacbd74d-dff1-47e5-a222-156f282f213e">
<img width="1728" alt="Screenshot 2024-11-18 at 10 13 23" src="https://github.com/user-attachments/assets/94bb6e7d-b1a1-4567-8fef-8853faab7cc3">
)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1368]: https://govukverify.atlassian.net/browse/LIME-1368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ