### PR TITLE
LIME-1369 logging added for auth source route

### DIFF
--- a/src/app/drivingLicence/controllers/root.js
+++ b/src/app/drivingLicence/controllers/root.js
@@ -1,4 +1,5 @@
 const { Controller: BaseController } = require("hmpo-form-wizard");
+const logger = require("hmpo-logger").get();
 
 const {
   API: {
@@ -82,6 +83,9 @@ class RootController extends BaseController {
       undefined === personInfoApiResponse?.data?.drivingPermit ||
       "" === personInfoApiResponse?.data?.drivingPermit
     ) {
+      logger.info(
+        "Root controller: drivingPermit data missing from API response"
+      );
       return false;
     } else {
       const drivingPermit = personInfoApiResponse?.data?.drivingPermit[0];
@@ -89,6 +93,9 @@ class RootController extends BaseController {
         undefined === drivingPermit?.personalNumber ||
         "" === drivingPermit?.personalNumber
       ) {
+        logger.info(
+          "Root controller: drivingPermit personalNumber data missing from API response"
+        );
         return false;
       }
 
@@ -96,6 +103,9 @@ class RootController extends BaseController {
         undefined === drivingPermit?.expiryDate ||
         "" === drivingPermit?.expiryDate
       ) {
+        logger.info(
+          "Root controller: drivingPermit expiryDate data missing from API response"
+        );
         return false;
       }
 
@@ -103,6 +113,9 @@ class RootController extends BaseController {
         undefined === drivingPermit?.issueDate ||
         "" === drivingPermit?.issueDate
       ) {
+        logger.info(
+          "Root controller: drivingPermit issueDate data missing from API response"
+        );
         return false;
       }
 
@@ -110,6 +123,9 @@ class RootController extends BaseController {
         undefined === drivingPermit?.issuedBy ||
         "" === drivingPermit?.issuedBy
       ) {
+        logger.info(
+          "Root controller: drivingPermit issuedBy data missing from API response"
+        );
         return false;
       }
 
@@ -118,6 +134,9 @@ class RootController extends BaseController {
           undefined === drivingPermit?.issueNumber ||
           "" === drivingPermit?.issueNumber
         ) {
+          logger.info(
+            "Root controller: drivingPermit issueNumber data missing from API response"
+          );
           return false;
         }
       }
@@ -127,10 +146,14 @@ class RootController extends BaseController {
       undefined === personInfoApiResponse?.data?.address ||
       "" === personInfoApiResponse?.data?.address
     ) {
+      logger.info("Root controller: address data missing from API response");
       return false;
     } else {
       const address = personInfoApiResponse?.data?.address[0];
       if (undefined === address?.postalCode || "" === address?.postalCode) {
+        logger.info(
+          "Root controller: address postalCode data missing from API response"
+        );
         return false;
       }
     }
@@ -139,10 +162,14 @@ class RootController extends BaseController {
       undefined === personInfoApiResponse?.data?.birthDate ||
       "" === personInfoApiResponse?.data?.birthDate
     ) {
+      logger.info("Root controller: birthDate data missing from API response");
       return false;
     } else {
       const birthDate = personInfoApiResponse?.data?.birthDate[0];
       if (undefined === birthDate.value || "" === birthDate.value) {
+        logger.info(
+          "Root controller: birthDate value data missing from API response"
+        );
         return false;
       }
     }
@@ -151,18 +178,28 @@ class RootController extends BaseController {
       undefined === personInfoApiResponse?.data?.name ||
       "" === personInfoApiResponse?.data?.name
     ) {
+      logger.info("Root controller: name data missing from API response");
       return false;
     } else {
       const name = personInfoApiResponse?.data?.name[0];
       if (undefined === name?.nameParts || "" === name?.nameParts) {
+        logger.info(
+          "Root controller: nameParts data missing from API response"
+        );
         return false;
       } else {
         const namePart = name?.nameParts[0];
         if (undefined === namePart || "" === namePart) {
+          logger.info(
+            "Root controller: namePart data missing from API response"
+          );
           return false;
         }
         for (let i = 0; i < namePart.length; i++) {
           if (undefined === namePart[i] || "" === namePart[i]) {
+            logger.info(
+              "Root controller: namePart value missing from API response"
+            );
             return false;
           }
         }

--- a/src/app/drivingLicence/controllers/root.test.js
+++ b/src/app/drivingLicence/controllers/root.test.js
@@ -1,33 +1,5 @@
 const RootController = require("./root");
 const { Controller: BaseController } = require("hmpo-form-wizard");
-let personInfoApiResponse = {
-  data: {
-    name: [
-      {
-        nameParts: [
-          { type: "GivenName", value: "KENNETH" },
-          { type: "FamilyName", value: "DECERQUEIRA" }
-        ]
-      }
-    ],
-    birthDate: [{ value: "1965-07-08" }],
-    address: [
-      {
-        postalCode: "BA2 5AA"
-      }
-    ],
-    drivingPermit: [
-      {
-        personalNumber: "DOE99751010AL9OD",
-        expiryDate: "2022-02-02",
-        issueNumber: "13",
-        issuedBy: "DVLA",
-        issueDate: "2012-02-02",
-        fullAddress: "8 HADLEY ROAD BATH BA2 5AA"
-      }
-    ]
-  }
-};
 
 describe("root controller", () => {
   const root = new RootController({ route: "/test" });
@@ -399,4 +371,425 @@ describe("root controller", () => {
     expect(req.sessionModel.get("surname")).to.equal(undefined);
     expect(req.sessionModel.get("dateOfBirth")).to.equal(undefined);
   });
+
+  it("should return false if personInfo response is missing name object", async () => {
+    personInfoApiResponse = {
+      data: {
+        birthDate: [{ value: "1965-07-08" }],
+        address: [
+          {
+            postalCode: "BA2 5AA"
+          }
+        ],
+        drivingPermit: [
+          {
+            personalNumber: "DOE99751010AL9OD",
+            expiryDate: "2022-02-02",
+            issueNumber: "13",
+            issuedBy: "DVLA",
+            issueDate: "2012-02-02",
+            fullAddress: "8 HADLEY ROAD BATH BA2 5AA"
+          }
+        ]
+      }
+    };
+
+    expect(
+      root.checkForValidSharedClaimsData(req, personInfoApiResponse)
+    ).to.equal(false);
+  });
+
+  it("should return false if personInfo response is missing nameParts objects", async () => {
+    personInfoApiResponse = {
+      name: [
+        {
+          nameParts: []
+        }
+      ],
+      data: {
+        birthDate: [{ value: "1965-07-08" }],
+        address: [
+          {
+            postalCode: "BA2 5AA"
+          }
+        ],
+        drivingPermit: [
+          {
+            personalNumber: "DOE99751010AL9OD",
+            expiryDate: "2022-02-02",
+            issueNumber: "13",
+            issuedBy: "DVLA",
+            issueDate: "2012-02-02",
+            fullAddress: "8 HADLEY ROAD BATH BA2 5AA"
+          }
+        ]
+      }
+    };
+
+    expect(
+      root.checkForValidSharedClaimsData(req, personInfoApiResponse)
+    ).to.equal(false);
+  });
+
+  it("should return false if personInfo response is missing birthDate object", async () => {
+    personInfoApiResponse = {
+      data: {
+        name: [
+          {
+            nameParts: [
+              { type: "GivenName", value: "KENNETH" },
+              { type: "FamilyName", value: "DECERQUEIRA" }
+            ]
+          }
+        ],
+        address: [
+          {
+            postalCode: "BA2 5AA"
+          }
+        ],
+        drivingPermit: [
+          {
+            personalNumber: "DOE99751010AL9OD",
+            expiryDate: "2022-02-02",
+            issueNumber: "13",
+            issuedBy: "DVLA",
+            issueDate: "2012-02-02",
+            fullAddress: "8 HADLEY ROAD BATH BA2 5AA"
+          }
+        ]
+      }
+    };
+
+    expect(
+      root.checkForValidSharedClaimsData(req, personInfoApiResponse)
+    ).to.equal(false);
+  });
+
+  it("should return false if personInfo response has empty string for birthDate value", async () => {
+    personInfoApiResponse = {
+      data: {
+        name: [
+          {
+            nameParts: [
+              { type: "GivenName", value: "KENNETH" },
+              { type: "FamilyName", value: "DECERQUEIRA" }
+            ]
+          }
+        ],
+        birthDate: [{ value: "" }],
+        address: [
+          {
+            postalCode: "BA2 5AA"
+          }
+        ],
+        drivingPermit: [
+          {
+            personalNumber: "DOE99751010AL9OD",
+            expiryDate: "2022-02-02",
+            issueNumber: "13",
+            issuedBy: "DVLA",
+            issueDate: "2012-02-02",
+            fullAddress: "8 HADLEY ROAD BATH BA2 5AA"
+          }
+        ]
+      }
+    };
+
+    expect(
+      root.checkForValidSharedClaimsData(req, personInfoApiResponse)
+    ).to.equal(false);
+  });
+
+  it("should return false if personInfo response is missing address object", async () => {
+    personInfoApiResponse = {
+      data: {
+        name: [
+          {
+            nameParts: [
+              { type: "GivenName", value: "KENNETH" },
+              { type: "FamilyName", value: "DECERQUEIRA" }
+            ]
+          }
+        ],
+        birthDate: [{ value: "1965-07-08" }],
+        drivingPermit: [
+          {
+            personalNumber: "DOE99751010AL9OD",
+            expiryDate: "2022-02-02",
+            issueNumber: "13",
+            issuedBy: "DVLA",
+            issueDate: "2012-02-02",
+            fullAddress: "8 HADLEY ROAD BATH BA2 5AA"
+          }
+        ]
+      }
+    };
+
+    expect(
+      root.checkForValidSharedClaimsData(req, personInfoApiResponse)
+    ).to.equal(false);
+  });
+  it("should return false if personInfo response is has empty string for postalCode value", async () => {
+    personInfoApiResponse = {
+      data: {
+        name: [
+          {
+            nameParts: [
+              { type: "GivenName", value: "KENNETH" },
+              { type: "FamilyName", value: "DECERQUEIRA" }
+            ]
+          }
+        ],
+        birthDate: [{ value: "1965-07-08" }],
+        address: [
+          {
+            postalCode: ""
+          }
+        ],
+        drivingPermit: [
+          {
+            personalNumber: "DOE99751010AL9OD",
+            expiryDate: "2022-02-02",
+            issueNumber: "13",
+            issuedBy: "DVLA",
+            issueDate: "2012-02-02",
+            fullAddress: "8 HADLEY ROAD BATH BA2 5AA"
+          }
+        ]
+      }
+    };
+
+    expect(
+      root.checkForValidSharedClaimsData(req, personInfoApiResponse)
+    ).to.equal(false);
+  });
+
+  it("should return false if personInfo response is missing drivingPermit object", async () => {
+    personInfoApiResponse = {
+      data: {
+        name: [
+          {
+            nameParts: [
+              { type: "GivenName", value: "KENNETH" },
+              { type: "FamilyName", value: "DECERQUEIRA" }
+            ]
+          }
+        ],
+        birthDate: [{ value: "1965-07-08" }],
+        address: [
+          {
+            postalCode: "BA2 5AA"
+          }
+        ]
+      }
+    };
+
+    expect(
+      root.checkForValidSharedClaimsData(req, personInfoApiResponse)
+    ).to.equal(false);
+  });
+
+  it("should return false if personInfo response has empty string for personalNumber value", async () => {
+    personInfoApiResponse = {
+      data: {
+        name: [
+          {
+            nameParts: [
+              { type: "GivenName", value: "KENNETH" },
+              { type: "FamilyName", value: "DECERQUEIRA" }
+            ]
+          }
+        ],
+        birthDate: [{ value: "1965-07-08" }],
+        address: [
+          {
+            postalCode: "BA2 5AA"
+          }
+        ],
+        drivingPermit: [
+          {
+            personalNumber: "",
+            expiryDate: "2022-02-02",
+            issueNumber: "13",
+            issuedBy: "DVLA",
+            issueDate: "2012-02-02",
+            fullAddress: "8 HADLEY ROAD BATH BA2 5AA"
+          }
+        ]
+      }
+    };
+
+    expect(
+      root.checkForValidSharedClaimsData(req, personInfoApiResponse)
+    ).to.equal(false);
+  });
+
+  it("should return false if personInfo response has empty string for expiryDate value", async () => {
+    personInfoApiResponse = {
+      data: {
+        name: [
+          {
+            nameParts: [
+              { type: "GivenName", value: "KENNETH" },
+              { type: "FamilyName", value: "DECERQUEIRA" }
+            ]
+          }
+        ],
+        birthDate: [{ value: "1965-07-08" }],
+        address: [
+          {
+            postalCode: "BA2 5AA"
+          }
+        ],
+        drivingPermit: [
+          {
+            personalNumber: "DOE99751010AL9OD",
+            expiryDate: "",
+            issueNumber: "13",
+            issuedBy: "DVLA",
+            issueDate: "2012-02-02",
+            fullAddress: "8 HADLEY ROAD BATH BA2 5AA"
+          }
+        ]
+      }
+    };
+
+    expect(
+      root.checkForValidSharedClaimsData(req, personInfoApiResponse)
+    ).to.equal(false);
+  });
+
+  it("should return false if personInfo response has empty string for issueNumber value", async () => {
+    personInfoApiResponse = {
+      data: {
+        name: [
+          {
+            nameParts: [
+              { type: "GivenName", value: "KENNETH" },
+              { type: "FamilyName", value: "DECERQUEIRA" }
+            ]
+          }
+        ],
+        birthDate: [{ value: "1965-07-08" }],
+        address: [
+          {
+            postalCode: "BA2 5AA"
+          }
+        ],
+        drivingPermit: [
+          {
+            personalNumber: "DOE99751010AL9OD",
+            expiryDate: "2022-02-02",
+            issueNumber: "",
+            issuedBy: "DVLA",
+            issueDate: "2012-02-02",
+            fullAddress: "8 HADLEY ROAD BATH BA2 5AA"
+          }
+        ]
+      }
+    };
+
+    expect(
+      root.checkForValidSharedClaimsData(req, personInfoApiResponse)
+    ).to.equal(false);
+  });
+
+  it("should return false if personInfo response has empty string for issuedBy value", async () => {
+    personInfoApiResponse = {
+      data: {
+        name: [
+          {
+            nameParts: [
+              { type: "GivenName", value: "KENNETH" },
+              { type: "FamilyName", value: "DECERQUEIRA" }
+            ]
+          }
+        ],
+        birthDate: [{ value: "1965-07-08" }],
+        address: [
+          {
+            postalCode: "BA2 5AA"
+          }
+        ],
+        drivingPermit: [
+          {
+            personalNumber: "DOE99751010AL9OD",
+            expiryDate: "2022-02-02",
+            issueNumber: "13",
+            issuedBy: "",
+            issueDate: "2012-02-02",
+            fullAddress: "8 HADLEY ROAD BATH BA2 5AA"
+          }
+        ]
+      }
+    };
+
+    expect(
+      root.checkForValidSharedClaimsData(req, personInfoApiResponse)
+    ).to.equal(false);
+  });
+
+  it("should return false if personInfo response has empty string for issuedDate value", async () => {
+    personInfoApiResponse = {
+      data: {
+        name: [
+          {
+            nameParts: [
+              { type: "GivenName", value: "KENNETH" },
+              { type: "FamilyName", value: "DECERQUEIRA" }
+            ]
+          }
+        ],
+        birthDate: [{ value: "1965-07-08" }],
+        address: [
+          {
+            postalCode: "BA2 5AA"
+          }
+        ],
+        drivingPermit: [
+          {
+            personalNumber: "DOE99751010AL9OD",
+            expiryDate: "2022-02-02",
+            issueNumber: "13",
+            issuedBy: "DVLA",
+            issueDate: "",
+            fullAddress: "8 HADLEY ROAD BATH BA2 5AA"
+          }
+        ]
+      }
+    };
+
+    expect(
+      root.checkForValidSharedClaimsData(req, personInfoApiResponse)
+    ).to.equal(false);
+  });
+
+  let personInfoApiResponse = {
+    data: {
+      name: [
+        {
+          nameParts: [
+            { type: "GivenName", value: "KENNETH" },
+            { type: "FamilyName", value: "DECERQUEIRA" }
+          ]
+        }
+      ],
+      birthDate: [{ value: "1965-07-08" }],
+      address: [
+        {
+          postalCode: "BA2 5AA"
+        }
+      ],
+      drivingPermit: [
+        {
+          personalNumber: "DOE99751010AL9OD",
+          expiryDate: "2022-02-02",
+          issueNumber: "13",
+          issuedBy: "DVLA",
+          issueDate: "2012-02-02",
+          fullAddress: "8 HADLEY ROAD BATH BA2 5AA"
+        }
+      ]
+    }
+  };
 });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

ECS logging added to root controller

### Why did it change

To facilitate troubleshooting when malformed person info data is received from our DL API on auth source journey 

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1369](https://govukverify.atlassian.net/browse/LIME-1369)

## Evidence

Expected sharedClaims JSON with all fields present:

`{
    "@context": [
        "https://www.w3.org/2018/credentials/v1",
        "https://vocab.london.cloudapps.digital/contexts/identity-v1.jsonld"
    ],
    "name": [
        {
            "nameParts": [
                {
                    "type": "Given",
                    "value": "KENNETH"
                },
                {
                    "type": "FamilyName",
                    "value": "DECERQUEIRA"
                }
            ]
        }
    ],
    "birthDate": [
        {
            "value": "1965-07-08"
        }
    ],
    "drivingPermit": [
      {
          "personalNumber": "DOE99751010AL9OD",
          "expiryDate": "2022-02-02",
          "issueDate": "2012-02-02",
          "issueNumber": "13",
          "issuedBy": "DVLA",
          "fullAddress": "8 HADLEY ROAD BATH BA2 5AA"
      }
    ]
}`

**Evidence for logging appearing in terminal as expected**
- Empty string for personalNumber in drivingPermit:

`..."drivingPermit": [
      {
          "personalNumber": "",
          "expiryDate": "2022-02-02",
          "issueDate": "2012-02-02",
          "issueNumber": "13",
          "issuedBy": "DVLA",
          "fullAddress": "8 HADLEY ROAD BATH BA2 5AA"
      }
    ]...`

![image](https://github.com/user-attachments/assets/b1af5c2e-2af7-45fc-adb5-12617870a2a7)


- Name object missing:

`    ..."birthDate": [
        {
            "value": "1965-07-08"
        }
    ],
    "drivingPermit": [
      {...`

![image](https://github.com/user-attachments/assets/42651ec9-98da-4a15-bfda-a3510b0c5862)


- drivingPermit object missing:

`                    ..."type": "FamilyName",
                    "value": "DECERQUEIRA"
                }
            ]
        }
    ],
    "birthDate": [...`

![image](https://github.com/user-attachments/assets/073feaff-050b-4d74-b205-8766ea97e661)


**Examples of scenarios where evidence can't be obtained**
- GivenName value with empty string:

`           ..."nameParts": [
                {
                    "type": "GivenName",
                    "value": ""
                },...`

Journey continues on Auth Source root with no terminal output
![image](https://github.com/user-attachments/assets/265212a0-0dda-4e75-9eec-d13032b6196a)


- empty string for birthDate value:

`  ..."birthDate": [
        {
            "value": ""
        }
    ],...`

Reach error screen and no terminal output:
![image](https://github.com/user-attachments/assets/f60cf550-90ba-409a-b229-7fe03a46b48a)


- birthDate object missing:

`                    ..."value": "DECERQUEIRA"
                }
            ]
        }
    ],
    "drivingPermit": [...`

Reach error screen and no terminal output:
![image](https://github.com/user-attachments/assets/eb51e749-93d8-4052-86ea-b4ad4b88b813)


[LIME-1369]: https://govukverify.atlassian.net/browse/LIME-1369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ