### PR TITLE
LIME-1363: Added new Auth Source UI Tests (including Welsh Translation)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test:watch": "mocha --watch",
     "mocks": "yarn run wiremock --port 8030 --root-dir test/mocks",
     "test:browser": "mkdir -p reports && wait-on tcp:127.0.0.1:8030 tcp:127.0.0.1:5030 && cucumber-js --config test/browser/cucumber.js",
-    "test:browser:ci": "npm-run-all -p -r start:ci mocks test:browser",
+    "test:browser:ci": "AUTH_SOURCE_ENABLED=true npm-run-all -p -r start:ci mocks test:browser",
     "check-translation": "node node_modules/@govuk-one-login/di-ipv-cri-common-express/scripts/checkTranslations.js '../../../../src/locales'"
   },
   "repository": {

--- a/src/app/drivingLicence/controllers/root.js
+++ b/src/app/drivingLicence/controllers/root.js
@@ -3,7 +3,6 @@ const logger = require("hmpo-logger").get();
 
 const {
   API: {
-    BASE_URL,
     PATHS: { PERSON_INFO }
   }
 } = require("../../../lib/config");
@@ -19,10 +18,9 @@ class RootController extends BaseController {
 
     if (process.env.AUTH_SOURCE_ENABLED === "true") {
       //axios.post to new personInfo endpoint, put licence details into req.session.shared_claims shared claims
-      const personInfoApiResponse = await req.axios.get(
-        `${BASE_URL}/${PERSON_INFO}`,
-        { headers: headers }
-      );
+      const personInfoApiResponse = await req.axios.get(`${PERSON_INFO}`, {
+        headers: headers
+      });
 
       req.sessionModel.set(
         "isAuthSourceRoute",

--- a/test/browser/features/English/DVA/DVAAuthSource.feature
+++ b/test/browser/features/English/DVA/DVAAuthSource.feature
@@ -1,0 +1,31 @@
+@mock-api:dl-dva-auth-success @success @DVA
+Feature: DVA Driving licence - Auth Source
+
+  Background:
+    Given Authenticatable Anita is using the system
+    And they have provided their details
+    When they have started the DL Auth Source journey
+
+  @mock-api:dl-dva-auth-success @validation-regression @build @staging
+  Scenario: DVA Auth Source - User navigates through the Auth Source Journey - Check Your Details Page
+    And I should be on the Driving Licence check your details page Check your UK photocard driving licence details – Prove your identity – GOV.UK
+    When I click on the Yes radio button
+    Then I click on the Confirm and Continue button
+    And I should be on the DVA consent page We need to check your driving licence details – Prove your identity – GOV.UK
+    And I click on the DVA consent checkbox
+    When I click on the Continue button
+
+  @mock-api:dl-dva-auth-success @validation-regression @build @staging
+  Scenario: DVA Auth Source - User selects No on the Check Your Details Page
+    And I should be on the Driving Licence check your details page Check your UK photocard driving licence details – Prove your identity – GOV.UK
+    When I click on the No radio button
+    Then I click on the Confirm and Continue button
+
+  @mock-api:dl-dva-auth-success @validation-regression @build @staging
+  Scenario: DVA Auth Source - User fails to provide consent on the Consent Page
+    And I should be on the Driving Licence check your details page Check your UK photocard driving licence details – Prove your identity – GOV.UK
+    When I click on the Yes radio button
+    Then I click on the Confirm and Continue button
+    And I should be on the DVA consent page We need to check your driving licence details – Prove your identity – GOV.UK
+    When I click on the Continue button
+    Then I see the No Consent Error Text You must give your consent to continue

--- a/test/browser/features/English/DVLA/DVLAAuthSource.feature
+++ b/test/browser/features/English/DVLA/DVLAAuthSource.feature
@@ -1,0 +1,31 @@
+@mock-api:dl-dvla-auth-success @success @DVLA
+Feature: DVLA Driving licence - Auth Source
+
+    Background:
+        Given Authenticatable Anita is using the system
+        And they have provided their details
+        When they have started the DL Auth Source journey
+
+    @mock-api:dl-dvla-auth-success @validation-regression @build @staging
+    Scenario: DVLA Auth Source - User navigates through the Auth Source Journey - Check Your Details Page
+        And I should be on the Driving Licence check your details page Check your UK photocard driving licence details – Prove your identity – GOV.UK
+        When I click on the Yes radio button
+        Then I click on the Confirm and Continue button
+        And I should be on the DVLA consent page We need to check your driving licence details – Prove your identity – GOV.UK
+        And I click on the DVLA consent checkbox
+        When I click on the Continue button
+
+    @mock-api:dl-dvla-auth-success @validation-regression @build @staging
+    Scenario: DVLA Auth Source - User selects No on the Check Your Details Page
+        And I should be on the Driving Licence check your details page Check your UK photocard driving licence details – Prove your identity – GOV.UK
+        When I click on the No radio button
+        Then I click on the Confirm and Continue button
+
+    @mock-api:dl-dvla-auth-success @validation-regression @build @staging
+    Scenario: DVLA Auth Source - User fails to provide consent on the Consent Page
+        And I should be on the Driving Licence check your details page Check your UK photocard driving licence details – Prove your identity – GOV.UK
+        When I click on the Yes radio button
+        Then I click on the Confirm and Continue button
+        And I should be on the DVLA consent page We need to check your driving licence details – Prove your identity – GOV.UK
+        When I click on the Continue button
+        Then I see the No Consent Error Text You must give your consent to continue

--- a/test/browser/features/Welsh/DVA/WelshDVAAuthSource.feature
+++ b/test/browser/features/Welsh/DVA/WelshDVAAuthSource.feature
@@ -1,0 +1,60 @@
+@mock-api:dl-dva-auth-success @success @DVA
+Feature: DVA Driving licence - Auth Source - Welsh Translation
+
+    Background:
+        Given Authenticatable Anita is using the system
+        And they have provided their details
+        When they have started the DL Auth Source journey
+        And I add a cookie to change the language to Welsh
+
+    @mock-api:dl-dva-auth-success @language-regression
+    Scenario: DVA Auth Source - Welsh Translation Tests - Check Your Answers Page
+        And I should be on the Driving Licence check your details page Gwirio manylion eich trwydded yrru cerdyn-llun yn y DU – Profi pwy ydych chi – GOV.UK
+
+    @mock-api:dl-dva-auth-success @language-regression
+    Scenario: DVA Auth Source - Welsh Translation Tests - Consent Page
+        When I click on the Yes radio button
+        Then I click on the Confirm and Continue button
+        And I should be on the DVA consent page Rydym angen gwirio manylion eich trwydded yrru – Profi pwy ydych chi – GOV.UK
+        And I click on the DVA consent checkbox
+        When I click on the Continue button
+
+    @mock-api:dl-dva-auth-success @language-regression
+    Scenario: DVA Auth Source - Welsh Translation Tests - Beta Banner
+        Given I view the beta banner on the check your answers page
+        And the beta banner on the check your answers page reads Mae hwn yn wasanaeth newydd – bydd eich adborth (agor mewn tab newydd) yn ein helpu i'w wella.
+
+    @mock-api:dl-dva-auth-success @language-regression
+    Scenario: DVA Auth Source - Welsh Translation Tests - Footer Links and Text
+        Given I see the check your answers accessibility statement link Datganiad hygyrchedd
+        And I see the check your answers cookies link Cwcis
+        And I see the check your answers terms and conditions link Telerau ac amodau
+        And I see the check your answers privacy notice link Hysbysiad preifatrwydd
+        And I see the check your answers support link Cymorth (agor mewn tab newydd)
+        And I see the check your answers OLG link Trwydded Llywodraeth Agored v3.0
+        And I see the check your answers crown copyright link © Hawlfraint y goron
+
+    @mock-api:dl-dva-auth-success @language-regression
+    Scenario: DVA Auth Source - Welsh Translation Tests - Details fields show correct text
+        Given I can see the check details lastName as Enw olaf
+        And I can see the check details givenNames as Enwau a roddwyd
+        And I can see the check details dob as Dyddiad geni
+        And I can see the check details issueDate as Dyddiad cyhoeddi
+        And I can see the check details validTo as Yn ddilys tan
+        And I can see the check details licenceNumber as Rhif trwydded
+        And I can see the DVA check details postcode as Cod post
+
+    @mock-api:dl-dva-auth-success @language-regression
+    Scenario: DVA Auth Source - Welsh Translation Tests - Check your Answers Page Text
+        Given I can see the DVA check details warning text as Gwnewch yn siŵr bod eich atebion yn gywir cyn i chi barhau.
+        And I can see the check details driving licence details correct as A yw manylion eich trwydded yrru cerdyn-llun yn y DU yn gywir?
+        And I can see the check details hint text as Gallwch geisio sganio'ch trwydded yrru eto neu brofi eich hunaniaeth mewn ffordd arall
+
+
+     @mock-api:dl-dva-auth-success @language-regression
+    Scenario: DVA Auth Source - Welsh Translation Tests - Consent Page Text
+        When I click on the Yes radio button
+        Then I click on the Confirm and Continue button
+        And I should be on the DVA consent page Rydym angen gwirio manylion eich trwydded yrru – Profi pwy ydych chi – GOV.UK
+        And I can see the consent page title as Rydym angen gwirio manylion eich trwydded yrru gyda'r DVA
+        And I can see the consent page text as Caniatau DVA i wirio eich manylion trwydded yrru

--- a/test/browser/features/Welsh/DVLA/WelshDVLA.feature
+++ b/test/browser/features/Welsh/DVLA/WelshDVLA.feature
@@ -386,7 +386,7 @@ Feature: DVLA Driving licence CRI Error Validations
 
     ##### Consent Checkbox Unselected error Validation ##### (passed)
   @mock-api:dvla-Consent-checkbox-error @language-regression
-  Scenario Outline:  DVLA Driving Licence error validation when DVLA consent checkbox is unselected
+  Scenario Outline: DVLA Driving Licence error validation when DVLA consent checkbox is unselected
     Given User enters DVLA data as a <DrivingLicenceSubject>
     And DVLA consent checkbox is unselected
     When User clicks on continue

--- a/test/browser/features/Welsh/DVLA/WelshDVLAAuthSource.feature
+++ b/test/browser/features/Welsh/DVLA/WelshDVLAAuthSource.feature
@@ -1,0 +1,61 @@
+@mock-api:dl-dvla-auth-success @success @DVLA
+Feature: DVLA Driving licence - Auth Source - Welsh Translation
+
+    Background:
+        Given Authenticatable Anita is using the system
+        And they have provided their details
+        When they have started the DL Auth Source journey
+        And I add a cookie to change the language to Welsh
+
+    @mock-api:dl-dvla-auth-success @language-regression
+    Scenario: DVLA Auth Source - Welsh Translation Tests - Check Your Answers Page
+        And I should be on the Driving Licence check your details page Gwirio manylion eich trwydded yrru cerdyn-llun yn y DU – Profi pwy ydych chi – GOV.UK
+
+    @mock-api:dl-dvla-auth-success @language-regression
+    Scenario: DVLA Auth Source - Welsh Translation Tests - Consent Page
+        When I click on the Yes radio button
+        Then I click on the Confirm and Continue button
+        And I should be on the DVLA consent page Rydym angen gwirio manylion eich trwydded yrru – Profi pwy ydych chi – GOV.UK
+        And I click on the DVLA consent checkbox
+        When I click on the Continue button
+
+    @mock-api:dl-dvla-auth-success @language-regression
+    Scenario: DVLA Auth Source - Welsh Translation Tests - Beta Banner
+        Given I view the beta banner on the check your answers page
+        And the beta banner on the check your answers page reads Mae hwn yn wasanaeth newydd – bydd eich adborth (agor mewn tab newydd) yn ein helpu i'w wella.
+
+    @mock-api:dl-dvla-auth-success @language-regression
+    Scenario: DVLA Auth Source - Welsh Translation Tests - Footer Links and Text
+        Given I see the check your answers accessibility statement link Datganiad hygyrchedd
+        And I see the check your answers cookies link Cwcis
+        And I see the check your answers terms and conditions link Telerau ac amodau
+        And I see the check your answers privacy notice link Hysbysiad preifatrwydd
+        And I see the check your answers support link Cymorth (agor mewn tab newydd)
+        And I see the check your answers OLG link Trwydded Llywodraeth Agored v3.0
+        And I see the check your answers crown copyright link © Hawlfraint y goron
+
+    @mock-api:dl-dvla-auth-success @language-regression
+    Scenario: DVLA Auth Source - Welsh Translation Tests - Details fields show correct text
+        Given I can see the check details lastName as Enw olaf
+        And I can see the check details givenNames as Enwau a roddwyd
+        And I can see the check details dob as Dyddiad geni
+        And I can see the check details issueDate as Dyddiad cyhoeddi
+        And I can see the check details validTo as Yn ddilys tan
+        And I can see the check details licenceNumber as Rhif trwydded
+        And I can see the DVLA check details issueNumber as Rhif cyhoeddi
+        And I can see the DVLA check details postcode as Cod post
+
+    @mock-api:dl-dvla-auth-success @language-regression
+    Scenario: DVLA Auth Source - Welsh Translation Tests - Check your Answers Page Text
+        Given I can see the DVA check details warning text as Gwnewch yn siŵr bod eich atebion yn gywir cyn i chi barhau.
+        And I can see the check details driving licence details correct as A yw manylion eich trwydded yrru cerdyn-llun yn y DU yn gywir?
+        And I can see the check details hint text as Gallwch geisio sganio'ch trwydded yrru eto neu brofi eich hunaniaeth mewn ffordd arall
+
+
+     @mock-api:dl-dva-auth-success @language-regression
+    Scenario: DVLA Auth Source - Welsh Translation Tests - Consent Page Text
+        When I click on the Yes radio button
+        Then I click on the Confirm and Continue button
+        And I should be on the DVLA consent page Rydym angen gwirio manylion eich trwydded yrru – Profi pwy ydych chi – GOV.UK
+        And I can see the consent page title as Rydym angen gwirio manylion eich trwydded yrru
+        And I can see the consent page text as Caniatau DVLA i wirio eich manylion trwydded yrru

--- a/test/browser/pages/CheckYourDetailsPage.js
+++ b/test/browser/pages/CheckYourDetailsPage.js
@@ -1,0 +1,298 @@
+const { expect: expect } = require("chai");
+exports.CheckYourDetailsPage = class PlaywrightDevPage {
+  constructor(page) {
+    this.page = page;
+    this.url = "http://localhost:5030/check-your-details";
+
+    this.radioBtnYes = this.page.locator('xpath=//*[@id="confirmDetails"]');
+
+    this.radioBtnNo = this.page.locator(
+      'xpath=//*[@id="confirmDetails-detailsNotConfirmed"]'
+    );
+
+    this.CTButton = this.page.locator(
+      'xpath=//*[@id="main-content"]/div/div/form/button'
+    );
+
+    this.betaBanner = this.page.locator("xpath=/html/body/div[2]/div/p/strong");
+
+    this.betaBannerReads = this.page.locator(
+      "xpath=/html/body/div[2]/div/p/span"
+    );
+
+    this.footerAccessibilityStatementText = this.page.locator(
+      "xpath=//html/body/footer/div/div/div[1]/ul/li[1]/a"
+    );
+
+    this.footerCookieText = this.page.locator(
+      "xpath=//html/body/footer/div/div/div[1]/ul/li[2]/a"
+    );
+
+    this.footerTermsAndConditionsText = this.page.locator(
+      "xpath=//html/body/footer/div/div/div[1]/ul/li[3]/a"
+    );
+
+    this.footerPrivacyNoticeText = this.page.locator(
+      "xpath=//html/body/footer/div/div/div[1]/ul/li[4]/a"
+    );
+
+    this.footerSupportText = this.page.locator(
+      "xpath=//html/body/footer/div/div/div[1]/ul/li[5]/a"
+    );
+
+    this.footerOpenGovernmentLicenceText = this.page.locator(
+      "xpath=//html/body/footer/div/div/div[1]/span/a"
+    );
+
+    this.footerCrownCopyrightText = this.page.locator(
+      "xpath=//html/body/footer/div/div/div[2]/a"
+    );
+
+    this.lastNameLabel = this.page.locator(
+      'xpath=//*[@id="main-content"]/div/div/form/dl[1]/div[1]/dt'
+    );
+
+    this.givenNamesLabel = this.page.locator(
+      'xpath=//*[@id="main-content"]/div/div/form/dl[1]/div[2]/dt'
+    );
+
+    this.dobLabel = this.page.locator(
+      'xpath=//*[@id="main-content"]/div/div/form/dl[1]/div[3]/dt'
+    );
+
+    this.issueDateLabel = this.page.locator(
+      'xpath=//*[@id="main-content"]/div/div/form/dl[1]/div[4]/dt'
+    );
+
+    this.validToNameLabel = this.page.locator(
+      'xpath=//*[@id="main-content"]/div/div/form/dl[1]/div[5]/dt'
+    );
+
+    this.licenceNumberNameLabel = this.page.locator(
+      'xpath=//*[@id="main-content"]/div/div/form/dl[1]/div[6]/dt'
+    );
+
+    this.issueNumberLabel = this.page.locator(
+      'xpath=//*[@id="main-content"]/div/div/form/dl[2]/div/dt'
+    );
+
+    this.dvaPostcodeLabel = this.page.locator(
+      'xpath=//*[@id="main-content"]/div/div/form/dl[2]/div/dt'
+    );
+
+    this.dvlaPostcodeLabel = this.page.locator(
+      '//*[@id="main-content"]/div/div/form/dl[3]/div/dt'
+    );
+
+    this.warningTextLabel = this.page.locator(
+      'xpath=//*[@id="main-content"]/div/div/div/strong'
+    );
+
+    this.drivingLicenceDetailsCorrectTextLabel = this.page.locator(
+      'xpath=//*[@id="main-content"]/div/div/form/h2'
+    );
+
+    this.hintTextLabel = this.page.locator(
+      'xpath=//*[@id="main-content"]/div/div/form/p'
+    );
+  }
+
+  isCurrentPage() {
+    return (
+      this.page.url() === this.url || this.page.url() === this.url + "?lng=cy"
+    );
+  }
+
+  async assertCheckYourDetailsPageTitle(checkYourDetailsPageTitle) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(await this.isCurrentPage()).to.be.true;
+    expect(await this.page.title()).to.equal(checkYourDetailsPageTitle);
+  }
+
+  async clickOnYesRadioButton() {
+    await this.radioBtnYes.click();
+  }
+
+  async clickOnNoRadioButton() {
+    await this.radioBtnNo.click();
+  }
+
+  async continue() {
+    await this.CTButton.click();
+  }
+
+  //  Language
+  async assertBetaBanner(betaBannerLabel) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(await this.isCurrentPage()).to.be.true;
+    await expect(await this.betaBanner.textContent()).to.contains(
+      betaBannerLabel
+    );
+  }
+
+  async assertBetaBannerText(assertBetaBannerText) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(await this.isCurrentPage()).to.be.true;
+    await expect(await this.betaBannerReads.textContent()).to.contains(
+      assertBetaBannerText
+    );
+  }
+
+  async assertFooterAccessibilityStatementText(
+    assertFooterAccessibilityStatementText
+  ) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(await this.isCurrentPage()).to.be.true;
+    await expect(
+      await this.footerAccessibilityStatementText.textContent()
+    ).to.contains(assertFooterAccessibilityStatementText);
+  }
+
+  async assertFooterCookieText(assertFooterCookieText) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(await this.isCurrentPage()).to.be.true;
+    await expect(await this.footerCookieText.textContent()).to.contains(
+      assertFooterCookieText
+    );
+  }
+
+  async assertFooterTermsAndConditonsText(assertFooterTermsAndConditonsText) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(await this.isCurrentPage()).to.be.true;
+    await expect(
+      await this.footerTermsAndConditionsText.textContent()
+    ).to.contains(assertFooterTermsAndConditonsText);
+  }
+
+  async assertFooterPrivacyNoticeText(assertFooterPrivacyNoticeText) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(await this.isCurrentPage()).to.be.true;
+    await expect(await this.footerPrivacyNoticeText.textContent()).to.contains(
+      assertFooterPrivacyNoticeText
+    );
+  }
+
+  async assertFooterSupportText(assertFooterSupportText) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(await this.isCurrentPage()).to.be.true;
+    await expect(await this.footerSupportText.textContent()).to.contains(
+      assertFooterSupportText
+    );
+  }
+
+  async assertFooterOpenGovernmentLicenceText(
+    assertFooterOpenGovernmentLicenceText
+  ) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(await this.isCurrentPage()).to.be.true;
+    await expect(
+      await this.footerOpenGovernmentLicenceText.textContent()
+    ).to.contains(assertFooterOpenGovernmentLicenceText);
+  }
+
+  async assertFooterCrownCopyrightText(assertFooterCrownCopyrightText) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(await this.isCurrentPage()).to.be.true;
+    await expect(await this.footerCrownCopyrightText.textContent()).to.contains(
+      assertFooterCrownCopyrightText
+    );
+  }
+
+  async assertLastName(checkYourDetailsLastName) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(await this.isCurrentPage()).to.be.true;
+    await expect(await this.lastNameLabel.textContent()).to.contains(
+      checkYourDetailsLastName
+    );
+  }
+
+  async assertGivenNames(checkYourDetailsGivenNames) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(await this.isCurrentPage()).to.be.true;
+    await expect(await this.givenNamesLabel.textContent()).to.contains(
+      checkYourDetailsGivenNames
+    );
+  }
+
+  async assertDob(checkYourDetailsDob) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(await this.isCurrentPage()).to.be.true;
+    await expect(await this.dobLabel.textContent()).to.contains(
+      checkYourDetailsDob
+    );
+  }
+
+  async assertIssueDate(checkYourDetailsIssueDate) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(await this.isCurrentPage()).to.be.true;
+    await expect(await this.issueDateLabel.textContent()).to.contains(
+      checkYourDetailsIssueDate
+    );
+  }
+
+  async assertValidTo(checkYourDetailsValidTo) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(await this.isCurrentPage()).to.be.true;
+    await expect(await this.validToNameLabel.textContent()).to.contains(
+      checkYourDetailsValidTo
+    );
+  }
+
+  async assertLicenceNumber(checkYourDetailsLicenceNumber) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(await this.isCurrentPage()).to.be.true;
+    await expect(await this.licenceNumberNameLabel.textContent()).to.contains(
+      checkYourDetailsLicenceNumber
+    );
+  }
+
+  async assertIssueNumber(checkYourDetailsIssueNumber) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(await this.isCurrentPage()).to.be.true;
+    await expect(await this.issueNumberLabel.textContent()).to.contains(
+      checkYourDetailsIssueNumber
+    );
+  }
+
+  async assertDvaPostcode(checkYourDetailsDvaPostcode) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(await this.isCurrentPage()).to.be.true;
+    await expect(await this.dvaPostcodeLabel.textContent()).to.contains(
+      checkYourDetailsDvaPostcode
+    );
+  }
+
+  async assertDvlaPostcode(checkYourDetailsDvlaPostcode) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(await this.isCurrentPage()).to.be.true;
+    await expect(await this.dvlaPostcodeLabel.textContent()).to.contains(
+      checkYourDetailsDvlaPostcode
+    );
+  }
+
+  async assertWarningText(checkYourDetailsWarningText) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(await this.isCurrentPage()).to.be.true;
+    await expect(await this.warningTextLabel.textContent()).to.contains(
+      checkYourDetailsWarningText
+    );
+  }
+
+  async assertDrivingLicenceDetailsCorrectText(
+    checkYourDetailsDrivingLicenceDetailsCorrectText
+  ) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(await this.isCurrentPage()).to.be.true;
+    await expect(
+      await this.drivingLicenceDetailsCorrectTextLabel.textContent()
+    ).to.contains(checkYourDetailsDrivingLicenceDetailsCorrectText);
+  }
+
+  async assertHintText(checkYourDetailsHintTextText) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(await this.isCurrentPage()).to.be.true;
+    await expect(await this.hintTextLabel.textContent()).to.contains(
+      checkYourDetailsHintTextText
+    );
+  }
+};

--- a/test/browser/pages/consent.js
+++ b/test/browser/pages/consent.js
@@ -1,0 +1,86 @@
+const { expect: expect } = require("chai");
+exports.ConsentPage = class PlaywrightDevPage {
+  /**
+   * @param {import('@playwright/test').Page} page
+   */
+  constructor(page) {
+    this.page = page;
+    this.url = "http://localhost:5030/consent";
+
+    this.consentButtonDVA = this.page.locator(
+      'xpath=//*[@id="consentDVACheckbox"]'
+    );
+
+    this.consentButtonDVLA = this.page.locator(
+      'xpath=//*[@id="consentCheckbox"]'
+    );
+
+    this.CTButton = this.page.locator(
+      'xpath=//*[@id="main-content"]/div/div/form/button'
+    );
+
+    this.noConsentProvidedErrorSummary = this.page.locator(
+      'xpath=//*[@id="main-content"]/div[1]/div/div/ul/li/a'
+    );
+
+    this.consentPageTitleLabel = this.page.locator('xpath=//*[@id="header"]');
+
+    this.consentPageTextLabel = this.page.locator(
+      'xpath=//*[@id="main-content"]/div/div/form/h2'
+    );
+  }
+
+  isCurrentPage() {
+    return (
+      this.page.url() === this.url || this.page.url() === this.url + "?lng=cy"
+    );
+  }
+
+  async assertConsentDVAPageTitle(consentPageTitle) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(await this.isCurrentPage()).to.be.true;
+    expect(await this.page.title()).to.equal(consentPageTitle);
+  }
+
+  async assertConsentDVLAPageTitle(consentPageTitle) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(await this.isCurrentPage()).to.be.true;
+    expect(await this.page.title()).to.equal(consentPageTitle);
+  }
+
+  async clickOnDVAConsentCheckBox() {
+    await this.consentButtonDVA.click();
+  }
+
+  async clickOnDVLAConsentCheckBox() {
+    await this.consentButtonDVLA.click();
+  }
+
+  async continue() {
+    await this.CTButton.click();
+  }
+
+  async assertNoConsentProvidedErrorSummary(errorSummaryText) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(await this.isCurrentPage()).to.be.true;
+    expect(await this.noConsentProvidedErrorSummary.innerText()).to.equal(
+      errorSummaryText
+    );
+  }
+
+  async assertConsentPageTitle(consentPageTitleText) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(await this.isCurrentPage()).to.be.true;
+    await expect(await this.consentPageTitleLabel.textContent()).to.contains(
+      consentPageTitleText
+    );
+  }
+
+  async assertConsentPageText(consentPageText) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(await this.isCurrentPage()).to.be.true;
+    await expect(await this.consentPageTextLabel.textContent()).to.contains(
+      consentPageText
+    );
+  }
+};

--- a/test/browser/pages/index.js
+++ b/test/browser/pages/index.js
@@ -1,5 +1,7 @@
 module.exports = {
   LicenceIssuerPage: require("./licence-issuer.js"),
+  CheckYourDetailsPage: require("./CheckYourDetailsPage.js"),
+  ConsentPage: require("./consent.js"),
   UniversalSteps: require("./UniversalSteps.js"),
   DrivingLicencePage: require("./DrivingLicencePage.js"),
   DVADetailsEntryPage: require("./DVADetailsEntryPage.js"),

--- a/test/browser/step_definitions/CheckYourDetailsStepDefs.js
+++ b/test/browser/step_definitions/CheckYourDetailsStepDefs.js
@@ -1,0 +1,229 @@
+const { Given, When, Then } = require("@cucumber/cucumber");
+
+const { CheckYourDetailsPage } = require("../pages/CheckYourDetailsPage");
+const { expect } = require("chai");
+
+When(/^they have started the DL Auth Source journey$/, async function () {});
+
+Then(
+  /^I should be on the Driving Licence check your details page (.*)$/,
+  async function (checkYourDetailsPageTitle) {
+    const checkYourDetailsPage = new CheckYourDetailsPage(this.page);
+    await checkYourDetailsPage.assertCheckYourDetailsPageTitle(
+      checkYourDetailsPageTitle
+    );
+  }
+);
+
+When(
+  /^I click on the Yes radio button$/,
+  { timeout: 2 * 5000 },
+  async function () {
+    const checkYourDetailsPage = new CheckYourDetailsPage(this.page);
+    expect(checkYourDetailsPage.isCurrentPage()).to.be.true;
+    await checkYourDetailsPage.clickOnYesRadioButton();
+  }
+);
+
+When(
+  /^I click on the No radio button$/,
+  { timeout: 2 * 5000 },
+  async function () {
+    const checkYourDetailsPage = new CheckYourDetailsPage(this.page);
+    expect(checkYourDetailsPage.isCurrentPage()).to.be.true;
+    await checkYourDetailsPage.clickOnNoRadioButton();
+  }
+);
+
+Then(
+  /^I view the (.*) banner on the check your answers page$/,
+  { timeout: 2 * 5000 },
+  async function (betaBannerLabel) {
+    const checkYourDetailsPage = new CheckYourDetailsPage(this.page);
+    await checkYourDetailsPage.assertBetaBanner(betaBannerLabel);
+  }
+);
+
+Then(
+  /^the beta banner on the check your answers page reads (.*)$/,
+  async function (betaBannerText) {
+    const checkYourDetailsPage = new CheckYourDetailsPage(this.page);
+    await checkYourDetailsPage.assertBetaBannerText(betaBannerText);
+  }
+);
+
+Then(
+  /^I click on the Confirm and Continue button$/,
+  { timeout: 2 * 5000 },
+  async function () {
+    const checkYourDetailsPage = new CheckYourDetailsPage(this.page);
+    expect(checkYourDetailsPage.isCurrentPage()).to.be.true;
+    await checkYourDetailsPage.continue();
+  }
+);
+
+Then(
+  /^I see the check your answers accessibility statement link (.*)$/,
+  async function (footerAccessibilityStatementText) {
+    const checkYourDetailsPage = new CheckYourDetailsPage(this.page);
+    await checkYourDetailsPage.assertFooterAccessibilityStatementText(
+      footerAccessibilityStatementText
+    );
+  }
+);
+
+Then(
+  /^I see the check your answers cookies link (.*)$/,
+  async function (footerCookieText) {
+    const checkYourDetailsPage = new CheckYourDetailsPage(this.page);
+    await checkYourDetailsPage.assertFooterCookieText(footerCookieText);
+  }
+);
+
+Then(
+  /^I see the check your answers terms and conditions link (.*)$/,
+  async function (footerTermsAndConditionsText) {
+    const checkYourDetailsPage = new CheckYourDetailsPage(this.page);
+    await checkYourDetailsPage.assertFooterTermsAndConditonsText(
+      footerTermsAndConditionsText
+    );
+  }
+);
+
+Then(
+  /^I see the check your answers privacy notice link (.*)$/,
+  async function (footerPrivacyNoticeText) {
+    const checkYourDetailsPage = new CheckYourDetailsPage(this.page);
+    await checkYourDetailsPage.assertFooterPrivacyNoticeText(
+      footerPrivacyNoticeText
+    );
+  }
+);
+
+Then(
+  /^I see the check your answers support link (.*)$/,
+  async function (footerSupportText) {
+    const checkYourDetailsPage = new CheckYourDetailsPage(this.page);
+    await checkYourDetailsPage.assertFooterSupportText(footerSupportText);
+  }
+);
+
+Then(
+  /^I see the check your answers OLG link (.*)$/,
+  async function (footerOpenGovernmentLicenceText) {
+    const checkYourDetailsPage = new CheckYourDetailsPage(this.page);
+    await checkYourDetailsPage.assertFooterOpenGovernmentLicenceText(
+      footerOpenGovernmentLicenceText
+    );
+  }
+);
+
+Then(
+  /^I see the check your answers crown copyright link (.*)$/,
+  async function (footerCrownCopyrightText) {
+    const checkYourDetailsPage = new CheckYourDetailsPage(this.page);
+    await checkYourDetailsPage.assertFooterCrownCopyrightText(
+      footerCrownCopyrightText
+    );
+  }
+);
+
+Then(
+  /^I can see the check details lastName as (.*)$/,
+  async function (checkYourDetailsLastName) {
+    const checkYourDetailsPage = new CheckYourDetailsPage(this.page);
+    await checkYourDetailsPage.assertLastName(checkYourDetailsLastName);
+  }
+);
+
+Then(
+  /^I can see the check details givenNames as (.*)$/,
+  async function (checkYourDetailsGivenNames) {
+    const checkYourDetailsPage = new CheckYourDetailsPage(this.page);
+    await checkYourDetailsPage.assertGivenNames(checkYourDetailsGivenNames);
+  }
+);
+
+Then(
+  /^I can see the check details dob as (.*)$/,
+  async function (checkYourDetailsDob) {
+    const checkYourDetailsPage = new CheckYourDetailsPage(this.page);
+    await checkYourDetailsPage.assertDob(checkYourDetailsDob);
+  }
+);
+
+Then(
+  /^I can see the check details issueDate as (.*)$/,
+  async function (checkYourDetailsIssueDate) {
+    const checkYourDetailsPage = new CheckYourDetailsPage(this.page);
+    await checkYourDetailsPage.assertIssueDate(checkYourDetailsIssueDate);
+  }
+);
+
+Then(
+  /^I can see the check details validTo as (.*)$/,
+  async function (checkYourDetailsValidTo) {
+    const checkYourDetailsPage = new CheckYourDetailsPage(this.page);
+    await checkYourDetailsPage.assertValidTo(checkYourDetailsValidTo);
+  }
+);
+
+Then(
+  /^I can see the check details licenceNumber as (.*)$/,
+  async function (checkYourDetailsLicenceNumber) {
+    const checkYourDetailsPage = new CheckYourDetailsPage(this.page);
+    await checkYourDetailsPage.assertLicenceNumber(
+      checkYourDetailsLicenceNumber
+    );
+  }
+);
+
+Then(
+  /^I can see the DVA check details postcode as (.*)$/,
+  async function (checkYourDetailsDvaPostcode) {
+    const checkYourDetailsPage = new CheckYourDetailsPage(this.page);
+    await checkYourDetailsPage.assertDvaPostcode(checkYourDetailsDvaPostcode);
+  }
+);
+
+Then(
+  /^I can see the DVLA check details postcode as (.*)$/,
+  async function (checkYourDetailsDvlaPostcode) {
+    const checkYourDetailsPage = new CheckYourDetailsPage(this.page);
+    await checkYourDetailsPage.assertDvlaPostcode(checkYourDetailsDvlaPostcode);
+  }
+);
+
+Then(
+  /^I can see the DVLA check details issueNumber as (.*)$/,
+  async function (checkYourDetailsIssueNumber) {
+    const checkYourDetailsPage = new CheckYourDetailsPage(this.page);
+    await checkYourDetailsPage.assertIssueNumber(checkYourDetailsIssueNumber);
+  }
+);
+
+Then(
+  /^I can see the DVA check details warning text as (.*)$/,
+  async function (checkYourDetailsWarningText) {
+    const checkYourDetailsPage = new CheckYourDetailsPage(this.page);
+    await checkYourDetailsPage.assertWarningText(checkYourDetailsWarningText);
+  }
+);
+
+Then(
+  /^I can see the check details driving licence details correct as (.*)$/,
+  async function (checkYourDetailsDrivingLicenceDetailsCorrectText) {
+    const checkYourDetailsPage = new CheckYourDetailsPage(this.page);
+    await checkYourDetailsPage.assertDrivingLicenceDetailsCorrectText(
+      checkYourDetailsDrivingLicenceDetailsCorrectText
+    );
+  }
+);
+
+Then(
+  /^I can see the check details hint text as (.*)$/,
+  async function (checkYourDetailsHintTextText) {
+    const checkYourDetailsPage = new CheckYourDetailsPage(this.page);
+    await checkYourDetailsPage.assertHintText(checkYourDetailsHintTextText);
+  }
+);

--- a/test/browser/step_definitions/consent.js
+++ b/test/browser/step_definitions/consent.js
@@ -1,0 +1,75 @@
+const { Given, When, Then } = require("@cucumber/cucumber");
+
+const { expect } = require("chai");
+
+const { ConsentPage } = require("../pages/consent");
+
+Then(
+  /^I should be on the DVA consent page (.*)$/,
+  async function (consentPageTitle) {
+    const consentPage = new ConsentPage(this.page);
+    await consentPage.assertConsentDVAPageTitle(consentPageTitle);
+  }
+);
+
+Then(
+  /^I should be on the DVLA consent page (.*)$/,
+  async function (consentPageTitle) {
+    const consentPage = new ConsentPage(this.page);
+    await consentPage.assertConsentDVLAPageTitle(consentPageTitle);
+  }
+);
+
+When(
+  /^I click on the DVA consent checkbox$/,
+  { timeout: 2 * 5000 },
+  async function () {
+    const consentPage = new ConsentPage(this.page);
+    expect(consentPage.isCurrentPage()).to.be.true;
+    await consentPage.clickOnDVAConsentCheckBox();
+  }
+);
+
+When(
+  /^I click on the DVLA consent checkbox$/,
+  { timeout: 2 * 5000 },
+  async function () {
+    const consentPage = new ConsentPage(this.page);
+    expect(consentPage.isCurrentPage()).to.be.true;
+    await consentPage.clickOnDVLAConsentCheckBox();
+  }
+);
+
+Then(
+  /^I click on the Continue button$/,
+  { timeout: 2 * 5000 },
+  async function () {
+    const consentPage = new ConsentPage(this.page);
+    expect(consentPage.isCurrentPage()).to.be.true;
+    await consentPage.continue();
+  }
+);
+
+Then(
+  /^I see the No Consent Error Text (.*)$/,
+  async function (errorSummaryText) {
+    const consentPage = new ConsentPage(this.page);
+    await consentPage.assertNoConsentProvidedErrorSummary(errorSummaryText);
+  }
+);
+
+Then(
+  /^I can see the consent page title as (.*)$/,
+  async function (consentPageTitleText) {
+    const consentPage = new ConsentPage(this.page);
+    await consentPage.assertConsentPageTitle(consentPageTitleText);
+  }
+);
+
+Then(
+  /^I can see the consent page text as (.*)$/,
+  async function (consentPageText) {
+    const consentPage = new ConsentPage(this.page);
+    await consentPage.assertConsentPageText(consentPageText);
+  }
+);

--- a/test/browser/step_definitions/details.js
+++ b/test/browser/step_definitions/details.js
@@ -2,12 +2,16 @@ const { Given } = require("@cucumber/cucumber");
 
 const { RelyingPartyPage } = require("../pages");
 
-Given(/^([A-Za-z ])+is using the system$/, async function (name) {
-  this.user = this.allUsers[name];
-  const rpPage = new RelyingPartyPage(this.page);
+Given(
+  /^([A-Za-z ])+is using the system$/,
+  { timeout: 10 * 1000 },
+  async function (name) {
+    this.user = this.allUsers[name];
+    const rpPage = new RelyingPartyPage(this.page);
 
-  await rpPage.goto();
-});
+    await rpPage.goto();
+  }
+);
 
 Given(
   "they have provided their details",

--- a/test/browser/support/env.js
+++ b/test/browser/support/env.js
@@ -4,6 +4,7 @@ require("playwright");
 
 const users = {
   "Authenticatable Anita": {},
+  "DL Auth Source Kenneth": {},
   "Erroring Ethem": {},
   "Not Authenticatable Neil": {},
   "Validating Valerie": {}

--- a/test/browser/support/setup.js
+++ b/test/browser/support/setup.js
@@ -8,9 +8,9 @@ BeforeAll(async function () {
     ? await chromium.launch()
     : await chromium.launch({
         // Not headless so we can watch test runs
-        headless: false,
+        headless: true,
         // Slow so we can see things happening
-        slowMo: 500
+        slowMo: 0
       });
 });
 
@@ -22,25 +22,25 @@ AfterAll(async function () {
 Before(async function ({ pickle } = {}) {
   const tags = pickle.tags || [];
   const tag = tags.find((tag) => tag.name.startsWith("@mock-api:"));
-
   if (!tag) {
     return;
   }
-
   const header = tag?.name.substring(10);
   if (!header) {
     return;
   }
-
   this.SCENARIO_ID_HEADER = header;
-
   const url = `http://localhost:8030/__reset/${header}`;
-
   try {
     await axios.get(url);
   } catch (e) {
     console.log(`Error fetching ${url}`); // eslint-disable-line no-console
     console.log(`${e.message}`); // eslint-disable-line no-console
+  }
+
+  // Set environment variable for specific tags
+  if (["dl-dva-auth-success", "dl-dvla-auth-success"].includes(header)) {
+    process.env.AUTH_SOURCE_ENABLED = "true";
   }
 });
 

--- a/test/mocks/mappings/dl-check-error.json
+++ b/test/mocks/mappings/dl-check-error.json
@@ -31,6 +31,24 @@
       }
     },
     {
+      "scenarioName": "dl-check-error",
+      "request": {
+        "method": "GET",
+        "urlPath": "/person-info",
+        "headers": {
+          "x-scenario-id": {
+            "equalTo": "drivingLicence-check-error"
+          },
+          "session_id": {
+            "equalTo": "ABADCAFE"
+          }
+        }
+      },
+      "response": {
+        "status": 204
+      }
+    },
+    {
       "scenarioName": "drivingLicence-check-error",
       "request": {
         "method": "POST",

--- a/test/mocks/mappings/driving-licence-dva-auth-source.json
+++ b/test/mocks/mappings/driving-licence-dva-auth-source.json
@@ -1,23 +1,23 @@
 {
   "mappings": [
     {
-      "scenarioName": "dl-success",
+      "scenarioName": "dl-dva-auth-success",
       "request": {
         "method": "GET",
-        "url": "/__reset/dl-success"
+        "url": "/__reset/dl-dva-auth-success"
       },
       "response": {
         "status": 200
       }
     },
     {
-      "scenarioName": "dl-success",
+      "scenarioName": "dl-dva-auth-success",
       "request": {
         "method": "POST",
         "urlPath": "/session",
         "headers": {
           "x-scenario-id": {
-            "equalTo": "dl-success"
+            "equalTo": "dl-dva-auth-success"
           }
         }
       },
@@ -30,14 +30,15 @@
         }
       }
     },
+
     {
-      "scenarioName": "dl-success",
+      "scenarioName": "dl-dva-auth-success",
       "request": {
         "method": "GET",
         "urlPath": "/person-info",
         "headers": {
           "x-scenario-id": {
-            "equalTo": "dl-success"
+            "equalTo": "dl-dva-auth-success"
           },
           "session_id": {
             "equalTo": "ABADCAFE"
@@ -45,17 +46,39 @@
         }
       },
       "response": {
-        "status": 204
+        "status": 200,
+        "jsonBody": {
+          "name": [
+            {
+              "nameParts": [
+                { "type": "GivenName", "value": "KENNETH" },
+                { "type": "FamilyName", "value": "DECERQUEIRA" }
+              ]
+            }
+          ],
+          "birthDate": [{ "value": "1965-07-08" }],
+          "address": [{ "postalCode": "BA2 5AA" }],
+          "drivingPermit": [
+            {
+              "personalNumber": "12345678",
+              "expiryDate": "2042-10-01",
+              "issuedBy": "DVA",
+              "issueDate": "2018-04-19",
+              "fullAddress": "8 HADLEY ROAD BATH BA2 5AA"
+            }
+          ]
+        }
       }
     },
+
     {
-      "scenarioName": "dl-success",
+      "scenarioName": "dl-dva-auth-success",
       "request": {
         "method": "POST",
         "urlPath": "/check-driving-licence",
         "headers": {
           "x-scenario-id": {
-            "equalTo": "dl-success"
+            "equalTo": "dl-dva-auth-success"
           },
           "session_id": {
             "equalTo": "ABADCAFE"
@@ -67,13 +90,13 @@
       }
     },
     {
-      "scenarioName": "dl-success",
+      "scenarioName": "dl-dva-auth-success",
       "request": {
         "method": "GET",
         "urlPath": "/authorization",
         "headers": {
           "x-scenario-id": {
-            "equalTo": "dl-success"
+            "equalTo": "dl-dva-auth-success"
           },
           "session-id": {
             "equalTo": "ABADCAFE"

--- a/test/mocks/mappings/driving-licence-dvla-auth-source.json
+++ b/test/mocks/mappings/driving-licence-dvla-auth-source.json
@@ -1,23 +1,23 @@
 {
   "mappings": [
     {
-      "scenarioName": "dl-success",
+      "scenarioName": "dl-dvla-auth-success",
       "request": {
         "method": "GET",
-        "url": "/__reset/dl-success"
+        "url": "/__reset/dl-dvla-auth-success"
       },
       "response": {
         "status": 200
       }
     },
     {
-      "scenarioName": "dl-success",
+      "scenarioName": "dl-dvla-auth-success",
       "request": {
         "method": "POST",
         "urlPath": "/session",
         "headers": {
           "x-scenario-id": {
-            "equalTo": "dl-success"
+            "equalTo": "dl-dvla-auth-success"
           }
         }
       },
@@ -30,14 +30,15 @@
         }
       }
     },
+
     {
-      "scenarioName": "dl-success",
+      "scenarioName": "dl-dvla-auth-success",
       "request": {
         "method": "GET",
         "urlPath": "/person-info",
         "headers": {
           "x-scenario-id": {
-            "equalTo": "dl-success"
+            "equalTo": "dl-dvla-auth-success"
           },
           "session_id": {
             "equalTo": "ABADCAFE"
@@ -45,17 +46,40 @@
         }
       },
       "response": {
-        "status": 204
+        "status": 200,
+        "jsonBody": {
+          "name": [
+            {
+              "nameParts": [
+                { "type": "GivenName", "value": "KENNETH" },
+                { "type": "FamilyName", "value": "DECERQUEIRA" }
+              ]
+            }
+          ],
+          "birthDate": [{ "value": "1965-07-08" }],
+          "address": [{ "postalCode": "BA2 5AA" }],
+          "drivingPermit": [
+            {
+              "personalNumber": "DECER607085K99AE",
+              "expiryDate": "2025-04-27",
+              "issuedBy": "DVLA",
+              "issueNumber": "16",
+              "issueDate": "2023-08-22",
+              "fullAddress": "8 HADLEY ROAD BATH BA2 5AA"
+            }
+          ]
+        }
       }
     },
+
     {
-      "scenarioName": "dl-success",
+      "scenarioName": "dl-dvla-auth-success",
       "request": {
         "method": "POST",
         "urlPath": "/check-driving-licence",
         "headers": {
           "x-scenario-id": {
-            "equalTo": "dl-success"
+            "equalTo": "dl-dvla-auth-success"
           },
           "session_id": {
             "equalTo": "ABADCAFE"
@@ -67,13 +91,13 @@
       }
     },
     {
-      "scenarioName": "dl-success",
+      "scenarioName": "dl-dvla-auth-success",
       "request": {
         "method": "GET",
         "urlPath": "/authorization",
         "headers": {
           "x-scenario-id": {
-            "equalTo": "dl-success"
+            "equalTo": "dl-dvla-auth-success"
           },
           "session-id": {
             "equalTo": "ABADCAFE"

--- a/test/mocks/mappings/driving-licence-fail.json
+++ b/test/mocks/mappings/driving-licence-fail.json
@@ -33,6 +33,24 @@
     {
       "scenarioName": "dl-failed",
       "request": {
+        "method": "GET",
+        "urlPath": "/person-info",
+        "headers": {
+          "x-scenario-id": {
+            "equalTo": "dl-failed"
+          },
+          "session_id": {
+            "equalTo": "ABCDEF"
+          }
+        }
+      },
+      "response": {
+        "status": 204
+      }
+    },
+    {
+      "scenarioName": "dl-failed",
+      "request": {
         "method": "POST",
         "urlPath": "/check-driving-licence",
         "headers": {

--- a/test/mocks/mappings/drivingLicence-slow.json
+++ b/test/mocks/mappings/drivingLicence-slow.json
@@ -33,6 +33,24 @@
     {
       "scenarioName": "driving-licence-success-slow",
       "request": {
+        "method": "GET",
+        "urlPath": "/person-info",
+        "headers": {
+          "x-scenario-id": {
+            "equalTo": "driving-licence-success-slow"
+          },
+          "session_id": {
+            "equalTo": "ABADCAFE"
+          }
+        }
+      },
+      "response": {
+        "status": 204
+      }
+    },
+    {
+      "scenarioName": "driving-licence-success-slow",
+      "request": {
         "method": "POST",
         "urlPath": "/check-driving-licence",
         "headers": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

Added new tests for DL Auth Source
Split between DVA Auth Source and DVLA Auth Source
Tests added for both DVA and DVLA Auth Source Welsh Translation Tests

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1363](https://govukverify.atlassian.net/browse/LIME-1363)

### Other considerations
All Tests passed locally when using 'yarn test:browser:ci:auth' command
![image](https://github.com/user-attachments/assets/72ea8772-03e6-431a-8272-66b96a6dd1dd)

[LIME-1363]: https://govukverify.atlassian.net/browse/LIME-1363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ