### PR TITLE
LIME-1492 Accessibility | Made a single definition list

### DIFF
--- a/src/views/drivingLicence/check-your-details.html
+++ b/src/views/drivingLicence/check-your-details.html
@@ -23,10 +23,10 @@
         }
     }) %}
 
+        {% if values.licenceIssuer == "DVLA" %}
 
-        {{ govukSummaryList({
-            classes: "govuk-!-margin-bottom-0",
-            rows: [
+            {{ govukSummaryList({
+                rows: [
                 {
                     key: {
                         text: translate("pages.check-your-details.lastName"),
@@ -80,31 +80,16 @@
                     value: {
                         text: values.drivingLicenceNumber
                     }
-                }
-            ]
-        }) }}
-
-        {% if values.licenceIssuer == "DVLA" %}
-
-            {{ govukSummaryList({
-                classes: "govuk-!-margin-bottom-0",
-                rows: [
-                    {
-                        key: {
-                            text: translate("pages.check-your-details.issueNumber"),
-                            classes: "govuk-!-font-weight-bold"
-                        },
-                        value: {
-                            text: values.issueNumber
-                        }
+                },
+                {
+                    key: {
+                        text: translate("pages.check-your-details.issueNumber"),
+                        classes: "govuk-!-font-weight-bold"
+                    },
+                    value: {
+                        text: values.issueNumber
                     }
-                ]
-            }) }}
-
-        {% endif %}
-
-        {{ govukSummaryList({
-            rows: [
+                },
                 {
                     key: {
                         text: translate("pages.check-your-details.postcode"),
@@ -116,6 +101,78 @@
                 }
             ]
         }) }}
+        {% endif %}
+
+        {% if values.licenceIssuer == "DVA" %}
+
+            {{ govukSummaryList({
+                rows: [
+                {
+                    key: {
+                        text: translate("pages.check-your-details.lastName"),
+                        classes: "govuk-!-font-weight-bold"
+                    },
+                    value: {
+                        text: values.surname
+                    }
+                },
+                {
+                    key: {
+                        text: translate("pages.check-your-details.givenNames"),
+                        classes: "govuk-!-font-weight-bold"
+                    },
+                    value: {
+                        text: values.firstName + " " + values.middleNames
+                    }
+                },
+                {
+                    key: {
+                        text: translate("pages.check-your-details.dateOfBirth"),
+                        classes: "govuk-!-font-weight-bold $govuk-text-colour"
+                    },
+                    value: {
+                        text: values.dateOfBirth
+                    }
+                },
+                {
+                    key: {
+                        text: translate("pages.check-your-details.issueDate"),
+                        classes: "govuk-!-font-weight-bold"
+                    },
+                    value: {
+                        text: values.issueDate
+                    }
+                },
+                {
+                    key: {
+                        text: translate("pages.check-your-details.validTo"),
+                        classes: "govuk-!-font-weight-bold"
+                    },
+                    value: {
+                        text: values.expiryDate
+                    }
+                },
+                {
+                    key: {
+                        text: translate("pages.check-your-details.licenceNumber"),
+                        classes: "govuk-!-font-weight-bold"
+                    },
+                    value: {
+                        text: values.drivingLicenceNumber
+                    }
+                },
+                {
+                    key: {
+                        text: translate("pages.check-your-details.postcode"),
+                        classes: "govuk-!-font-weight-bold"
+                    },
+                    value: {
+                        text: values.postcode
+                    }
+                }
+            ]
+        }) }}
+        {% endif %}
 
         <h2>{{ translate("pages.check-your-details.correctCheck") }}</h2>
 

--- a/test/browser/pages/CheckYourDetailsPage.js
+++ b/test/browser/pages/CheckYourDetailsPage.js
@@ -73,15 +73,15 @@ exports.CheckYourDetailsPage = class PlaywrightDevPage {
     );
 
     this.issueNumberLabel = this.page.locator(
-      'xpath=//*[@id="main-content"]/div/div/form/dl[2]/div/dt'
+      'xpath=//*[@id="main-content"]/div/div/form/dl[1]/div[7]/dt'
     );
 
     this.dvaPostcodeLabel = this.page.locator(
-      'xpath=//*[@id="main-content"]/div/div/form/dl[2]/div/dt'
+      'xpath=//*[@id="main-content"]/div/div/form/dl[1]/div[7]/dt'
     );
 
     this.dvlaPostcodeLabel = this.page.locator(
-      '//*[@id="main-content"]/div/div/form/dl[3]/div/dt'
+      'xpath=//*[@id="main-content"]/div/div/form/dl[1]/div[8]/dt'
     );
 
     this.warningTextLabel = this.page.locator(


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes
This is an accessibility requirement for the Authoritative Source initiative to make a single definition list for UK driving licences to aid the use of assistive tech.

### What changed

The definition list for UK driving licences was implemented as 3 definition lists, this has been changed to be one list for either DVA or DVLA in the check-your-details.html view.

Changes show the correct form format in check your details view.
Check your details page for DVLA:
![image](https://github.com/user-attachments/assets/0c5c40c4-9857-482a-bbeb-ee5870244454)

Check your details page for DVA:
![image](https://github.com/user-attachments/assets/e94a4147-1f67-4735-abfa-e0a3c55e42d0)


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1492](https://govukverify.atlassian.net/browse/LIME-1492)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1492]: https://govukverify.atlassian.net/browse/LIME-1492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ