### PR TITLE
LIME-1494 Accessibility | extra letter spacing added to licence number in Check Your Details view

### DIFF
--- a/src/views/drivingLicence/check-your-details.html
+++ b/src/views/drivingLicence/check-your-details.html
@@ -78,7 +78,8 @@
                         classes: "govuk-!-font-weight-bold"
                     },
                     value: {
-                        text: values.drivingLicenceNumber
+                        text: values.drivingLicenceNumber,
+                        classes: "govuk-input--extra-letter-spacing"
                     }
                 },
                 {
@@ -158,7 +159,8 @@
                         classes: "govuk-!-font-weight-bold"
                     },
                     value: {
-                        text: values.drivingLicenceNumber
+                        text: values.drivingLicenceNumber,
+                        classes: "govuk-input--extra-letter-spacing"
                     }
                 },
                 {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

Apply the govuk-input--extra-letter-spacing CSS class to improve readability of licence numbers. 

### What changed

govuk-input--extra-letter-spacing class added to the value key in check-your-details.html

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1494 ](https://govukverify.atlassian.net/browse/LIME-1494 )

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->
