### PR TITLE
LIME-1495 updating summary-list_key elements to be in bold

### DIFF
--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -12,6 +12,12 @@ $govuk-assets-path: "/public/";
   background-color: $govuk-error-colour;
 }
 
+// ensures Govuk-summary-list__key elements are in bold primary text
+
+.govuk-summary-list .govuk-summary-list__key {
+  color: $govuk-text-colour;
+}
+
 //// Task list pattern
 //
 //.app-task-list {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

Ensure the Govuk-summary-list__key elements are in bold primary text ($govuk-text-colour) 

### What changed

Added  $govuk-text-colour to application.scss file

### Why did it change

Summary list key elements were appearing as secondary text colour

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1495 ](https://govukverify.atlassian.net/browse/LIME-1495 )

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->
