### PR TITLE
LIME-1229 increases Dependabot open PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
     target-branch: main
     labels:
       - dependabot
+    open-pull-requests-limit: 20
     ignore:
       - dependency-name: "node"
         versions: ["17.x", "18.x"]


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

Changes made to update dependabot open PR limit to 20 due to present limit of 5 being too few given some PRs can be blocked for some time. 

This FE repo has no dependencies that require grouping so no update made regarding grouping dependencies. 

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1229](https://govukverify.atlassian.net/browse/LIME-1229)

[LIME-1229]: https://govukverify.atlassian.net/browse/LIME-1229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ