### PR TITLE
LIME-1482 Updated licence issuer page for Low Confidence journey

### DIFF
--- a/src/locales/cy/fields.yml
+++ b/src/locales/cy/fields.yml
@@ -142,7 +142,7 @@ consentCheckbox:
     default: "Mae'n rhaid i chi roi eich caniatâd i barhau"
 
 licenceIssuer:
-  hint: ""
+  hint: Mae hwn i'w weld yn adran 4c o'ch trwydded yrru. Bydd naill ai’n dweud DVLA (Asiantaeth Trwyddedu Gyrru a Cherbydau) neu DVA (Asiantaeth Gyrwyr a Cherbydau).
   content: ""
   validation:
     required: Mae'n rhaid i chi ddewis opsiwn i barhau
@@ -150,18 +150,18 @@ licenceIssuer:
     DVLA:
       label: DVLA
       value: DVLA
-      hint: ""
+      hint: Trwyddedau gyrru a chyhoeddwyd yng Nghymru, Lloegr a'r Alban.
       reveal: ""
     DVA:
       label: DVA
       value: DVA
-      hint: ""
+      hint: Trwyddedau gyrru a chyhoeddwyd yng Ngogledd Iwerddon.
       reveal: ""
     or:
       label: neu
       value: or
     noLicence:
-      label: Nid oes gennyf drwydded yrru y DU
+      label: Nid oes gennyf drwydded yrru cerdyn-llun y DU
       value: noLicence
       hint: ""
       reveal: ""

--- a/src/locales/cy/pages.yml
+++ b/src/locales/cy/pages.yml
@@ -1,12 +1,10 @@
 # title is managed in default.yml
 licence-issuer:
-  title: Pwy wnaeth gyhoeddi eich trwydded yrru y DU?
-  content:
-    - Gallwch ddod o hyd i hwn yn adran 4c o'ch trwydded yrru. Bydd naill ai'n dweud DVLA (Asiantaeth Trwyddedu Gyrru a Cherbydau) neu DVA (Asiantaeth Gyrrwyr a Cherbydau).
+  title: A oedd eich trwydded yrru cerdyn-llun y DU wedi'i chyhoeddi gan DVLA neu DVA?
   details:
     summary: Pam rydym angen gwybod hyn
     text:
-      - Mae angen i ni sicrhau ein bod yn gwirio manylion eich trwydded yrru gyda'r sefydliad cywir. Mae DVLA yn cyhoeddi trwyddedau gyrru yng Nghymru, Lloegr a'r Alban. Mae DVA yn cyhoeddi trwyddedau gyrru yng Ngogledd Iwerddon.
+      - Mae angen i ni sicrhau ein bod yn gwirio manylion eich trwydded yrru gyda'r sefydliad cywir.
 
 details:
   title: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru

--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -142,7 +142,7 @@ consentCheckbox:
     default: "You must give your consent to continue"
 
 licenceIssuer:
-  hint: ""
+  hint: "You can find this in section 4c of your driving licence. It will either say DVLA (Driving and vehicle Licensing Agency) or DVA (Driver and Vehicle Agency)."
   content: ""
   validation:
     required: You must choose an option to continue
@@ -150,18 +150,18 @@ licenceIssuer:
     DVLA:
       label: DVLA
       value: DVLA
-      hint: ""
+      hint: "Driving licences issued in England, Scotland and Wales."
       reveal: ""
     DVA:
       label: DVA
       value: DVA
-      hint: ""
+      hint: "Driving licenses issued in Northern Ireland."
       reveal: ""
     or:
       label: or
       value: or
     noLicence:
-      label: I do not have a UK driving licence
+      label: I do not have a UK photocard driving licence
       value: noLicence
       hint: ""
       reveal: ""

--- a/src/locales/en/pages.yml
+++ b/src/locales/en/pages.yml
@@ -1,12 +1,10 @@
 # title is managed in default.yml
 licence-issuer:
-  title: Who was your UK driving licence issued by?
-  content:
-    - You can find this in section 4c of your driving licence. It will either say DVLA (Driving and vehicle Licensing Agency) or DVA (Driver and Vehicle Agency).
+  title: Was your UK photocard driving licence issued by DVLA or DVA?
   details:
     summary: Why we need to know this
     text:
-      - We need to make sure we check your driving licence details with the right organisation. DVLA issues driving licences in England, Scotland and Wales. DVA issues driving licences in Northern Ireland.
+      - We need to make sure we check your driving licence details with the right organisation.
 
 details:
   title: Enter your details exactly as they appear on your UK driving licence

--- a/src/views/drivingLicence/licence-issuer.html
+++ b/src/views/drivingLicence/licence-issuer.html
@@ -20,13 +20,14 @@
 id: "licenceIssuer"
 }) }}
 
-{% block submitButton %}
-    {{ hmpoSubmit(ctx, {id: 'submitButton'}) }}
-
 {{ govukDetails({
         summaryText: translate("pages.licence-issuer.details.summary"),
         text: translate("pages.licence-issuer.details.text")
 }) }}
+
+{% block submitButton %}
+    {{ hmpoSubmit(ctx, {id: 'submitButton'}) }}
+    
 {% endblock %}
 
 {% endcall %}

--- a/test/browser/pages/licence-issuer.js
+++ b/test/browser/pages/licence-issuer.js
@@ -22,7 +22,7 @@ module.exports = class PlaywrightDevPage {
 
   async clickOnDVLARadioButton() {
     expect(await this.page.title()).to.equal(
-      "Who was your UK driving licence issued by? – Prove your identity – GOV.UK"
+      "Was your UK photocard driving licence issued by DVLA or DVA? – Prove your identity – GOV.UK"
     );
     await this.radioBtnDVLA.click();
     await this.CTButton.click();
@@ -34,7 +34,7 @@ module.exports = class PlaywrightDevPage {
 
   async clickOnDVARadioButton() {
     expect(await this.page.title()).to.equal(
-      "Who was your UK driving licence issued by? – Prove your identity – GOV.UK"
+      "Was your UK photocard driving licence issued by DVLA or DVA? – Prove your identity – GOV.UK"
     );
     await this.radioBtnDVA.click();
     await this.CTButton.click();


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

Update the hint text in the Driving Licence CRI, to provide clarity to a user on whether they should select ‘DVA’ or ‘DVLA’ on the 'Was your UK photocard driving licence issued by DVLA or DVA?' screen.

### What changed

- Header updated to Was your UK photocard driving licence issued by DVLA or DVA?
- Browser test for licence issuer page updated to reflect title change
- hint added to licence issuer to fields.yml
- hints added to radio buttons in fields.yml
- addition of 'photocard' to radio button lebel in fields.yml
- text removed from details text in pages.yml
- continue button moved to sit below "Why we need to know this" component

English has been added temporarily to Welsh translation pages to pass pre-merge checks.

Screen matches new design:
![image](https://github.com/user-attachments/assets/66c53940-ba3c-49cf-b2b8-3512d47d122d)

UI tests pass:
![image](https://github.com/user-attachments/assets/6ed59d15-5c74-48f1-9e41-d9856051dd52)


Welsh translation added:
![image](https://github.com/user-attachments/assets/05269898-25bd-4c87-b24c-ccf06787f419)


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1482](https://govukverify.atlassian.net/browse/LIME-1482)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1482]: https://govukverify.atlassian.net/browse/LIME-1482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ