### PR TITLE
Update to  exclude the origin load balancer from the regional FMS policy

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,6 +91,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -306,23 +310,23 @@
         "filename": "deploy/template.yaml",
         "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
         "is_verified": false,
-        "line_number": 643
+        "line_number": 646
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "42af5cf9fcf4f09147c032a0fb4877f5cf626bbc",
         "is_verified": false,
-        "line_number": 644
+        "line_number": 647
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "7584a31168b8e8f62d9b84b7b95d239b99fad815",
         "is_verified": false,
-        "line_number": 646
+        "line_number": 649
       }
     ]
   },
-  "generated_at": "2025-01-17T13:13:51Z"
+  "generated_at": "2025-02-03T09:04:33Z"
 }

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -246,6 +246,9 @@ Resources:
           - Key: access_logs.s3.prefix
             Value: !Sub driving-permit-front-${Environment}
         - !Ref AWS::NoValue
+      Tags:
+        - Key: FMSRegionalPolicy
+          Value: false
 
   LoadBalancerListenerTargetGroupECS:
     Type: "AWS::ElasticLoadBalancingV2::TargetGroup"


### PR DESCRIPTION
This is protected by a specific WAF for CloudFront

## Proposed changes

Added tags to exclude the origin load balancer from FMS as it has it's own CloudFront specific WAF

### What changed
Added tags

### Why did it change
to exclude the origin load balancer from FMS as it has it's own CloudFront specific WAF

### Issue tracking
https://govukverify.atlassian.net/browse/IPS-1407
