### PR TITLE
LIME-1546 Upgrading FE Vital signs to log max EventLoopDelay

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@govuk-one-login/frontend-analytics": "2.0.1",
     "@govuk-one-login/frontend-language-toggle": "1.1.0",
     "@govuk-one-login/frontend-passthrough-headers": "1.1.1",
-    "@govuk-one-login/frontend-vital-signs": "0.1.1",
+    "@govuk-one-login/frontend-vital-signs": "0.1.3",
     "axios": "1.7.7",
     "cfenv": "1.2.4",
     "connect-dynamodb": "3.0.3",


### PR DESCRIPTION
### What changed
Upgrading FE Vital signs to log max EventLoopDelay (fix brought in by latest patch version)