### PR TITLE
LIME-1530 - Added new Common Tests for Driving Licence Landing Page

### DIFF
--- a/test/browser/features/English/DLCommon/DLCommon.feature
+++ b/test/browser/features/English/DLCommon/DLCommon.feature
@@ -1,0 +1,118 @@
+@mock-api:dl-success @success @DVA
+Feature: Driving licence CRI - Common Tests
+
+    Background:
+        Given Authenticatable Anita is using the system
+        And they have provided their details
+        And they have started the DL journey
+
+    @mock-api:driving-licence-PageHeading @validation-regression
+    Scenario: Driving Licence - Landing Page Title and Text
+        Given I should be on the Landing Page with Page Title Was your UK photocard driving licence issued by DVLA or DVA?
+        And I see the Landing Page Title Summary Text You can find this in section 4c of your driving licence. It will either say DVLA (Driving and vehicle Licensing Agency) or DVA (Driver and Vehicle Agency).
+
+    @mock-api:driving-licence-RadioButtons @validation-regression
+    Scenario: Driving Licence - Landing Page displays correct radio button options for DVA and DVLA
+        Given I see the radio button for DVLA
+        Then The DVLA Radio button label reads DVLA
+        And The DVLA Hint text reads Driving licences issued in England, Scotland and Wales.
+        And I see the radio button for DVA
+        Then The DVA Radio button label reads DVA
+        And The DVA Hint text reads Driving licenses issued in Northern Ireland.
+        And I see the radio button for I do not have a UK photocard driving licence
+        Then The third Radio button label reads I do not have a UK photocard driving licence
+
+    @mock-api:driving-licence-InvalidRadioSelection @validation-regression
+    Scenario: Driving Licence - Landing Page - There is a problem error displays when no radio button is selected
+        Given I click the continue button without selecting a radio button option
+        Then I see the Error Text There is a problem
+        And I see the Error Summary Text You must choose an option to continue
+        And I see the Hint Error Summary Text You must choose an option to continue
+
+    @mock-api:driving-licence-DropDownLink @validation-regression
+    Scenario: Driving Licence - Landing Page Drop Down - 'Why we need to know this'
+        Given I see the Drop Down link for Why we need to know this
+        And User clicks the Drop Down button
+        Then I see the drop down text as We need to make sure we check your driving licence details with the right organisation.
+
+    @mock-api:driving-licence-Cookies @validation-regression
+    Scenario: Driving Licence - User Clicks the Accept Cookies on the Cookie Banner
+        Given The cookie banner is displayed
+        When User clicks on the Accept Cookie Button
+        Then I see the Cookie Banner Accept text as You’ve accepted additional cookies. You can change your cookie settings at any time.
+        Then User clicks on the Accept Hide this message button
+
+    @mock-api:driving-licence-Cookies @validation-regression
+    Scenario: Driving Licence - User Clicks the Reject Cookies on the Cookie Banner
+        Given The cookie banner is displayed
+        When User clicks on the Reject Cookie Button
+        Then I see the Cookie Banner Reject text as You’ve rejected additional cookies. You can change your cookie settings at any time.
+        Then User clicks on the Reject Hide this message button
+
+    @mock-api:driving-licence-Cookies @validation-regression
+    Scenario: Driving Licence - User Clicks the View Cookies on the Cookie Banner
+        Given The cookie banner is displayed
+        When User clicks on the View Cookies Link
+        And I check the Cookies page Title GOV.UK One Login cookies policy – GOV.UK One Login
+
+    @mock-api:driving-licence-Cookies @validation-regression
+    Scenario: Driving Licence - User Clicks the change your cookie settings after Accepting Cookies on the Cookie Banner
+        Given The cookie banner is displayed
+        When User clicks on the Accept Cookie Button
+        Then User click the change your cookie settings link
+        And I check the Cookies page Title GOV.UK One Login cookies policy – GOV.UK One Login
+
+    @mock-api:driving-licence-BetaBanner @validation-regression
+    Scenario: Driving Licence - GOV.UK Beta Banner
+        Given The beta banner is displayed
+        And The beta banner reads This is a new service – your feedback (opens in new tab) will help us to improve it.
+        When User clicks on the Feedback Link
+        And I check the Feedback page Title Contact GOV.UK One Login
+
+    @mock-api:driving-licence-PageHeading @validation-regression
+    Scenario: Driving Licence - Header - GOV.UK Link
+        Given I see the GOV.UK footer link with the text GOV.UK
+        When User clicks the GOV.UK Link
+        And I check the GOV.UK page Title GOV.UK
+
+    @mock-api:driving-licence-PageFooter @validation-regression
+    Scenario: Driving Licence - Footer - Accessibility statement
+        Given I see the Accessibility statement footer link with the text Accessibility statement
+        When User clicks the Accessibiliy statement Link
+        And I check the Accessibiliy statement page Title Accessibility statement for GOV.UK One Login – GOV.UK One Login
+
+    @mock-api:driving-licence-PageFooter @validation-regression
+    Scenario: Driving Licence - Footer - Cookies
+        Given I see the Cookies footer link with the text Cookies
+        When User clicks the Cookies Link
+        And I check the Cookies page Title GOV.UK One Login cookies policy – GOV.UK One Login
+
+    @mock-api:driving-licence-PageFooter @validation-regression
+    Scenario: Driving Licence - Footer - Terms and Conditions
+        Given I see the Terms and conditions footer link with the text Terms and conditions
+        When User clicks the Terms and conditions Link
+        And I check the Terms and conditions page Title GOV.UK One Login terms and conditions – GOV.UK One Login
+
+    @mock-api:driving-licence-PageFooter @validation-regression
+    Scenario: Driving Licence - Footer - Privacy Notice
+        Given I see the Privacy notice footer link with the text Privacy notice
+        When User clicks the Privacy notice Link
+        And I check the Privacy notice page Title GOV.UK One Login privacy notice – GOV.UK One Login
+
+    @mock-api:driving-licence-PageFooter @validation-regression
+    Scenario: Driving Licence - Footer - Support (opens in new tab)
+        Given I see the Support footer link with the text Support (opens in new tab)
+        When User clicks the Support Link
+        And I check the Support page Title Contact GOV.UK One Login – GOV.UK One Login
+
+    @mock-api:driving-licence-PageFooter @validation-regression
+    Scenario: Driving Licence - Footer - Crown Copyright
+        Given I see the Crown Copyright footer link with the text © Crown copyright
+        When User clicks the Crown Copyright Link
+        And I check the Crown Copyright page Title Contact GOV.UK One Login – GOV.UK One Login
+
+    @mock-api:driving-licence-PageFooter @validation-regression
+    Scenario: Driving Licence - Footer - Open Government Licence v3.0
+        Given I see the OGL footer link with the text All content is available under the Open Government Licence v3.0, except where otherwise stated.
+        When User clicks the OGL Link
+        And I check the OGL page Title Open Government Licence for public sector information

--- a/test/browser/features/English/DLCommon/WelshDLCommon.feature
+++ b/test/browser/features/English/DLCommon/WelshDLCommon.feature
@@ -1,0 +1,100 @@
+@mock-api:dl-success @success @DVA
+Feature: Driving licence CRI - Common Tests - Welsh Translation
+
+    Background:
+        Given Authenticatable Anita is using the system
+        And they have provided their details
+        And they have started the DL journey
+        And I add a cookie to change the language to Welsh
+
+    @mock-api:driving-licence-PageHeading @validation-regression
+    Scenario: Driving Licence - Landing Page Title and Text
+        Given I should be on the Landing Page with Page Title A oedd eich trwydded yrru cerdyn-llun y DU wedi'i chyhoeddi gan DVLA neu DVA?
+        And I see the Landing Page Title Summary Text Mae hwn i'w weld yn adran 4c o'ch trwydded yrru. Bydd naill ai’n dweud DVLA (Asiantaeth Trwyddedu Gyrru a Cherbydau) neu DVA (Asiantaeth Gyrwyr a Cherbydau).
+
+    @mock-api:driving-licence-RadioButtons @validation-regression
+    Scenario: Driving Licence - Landing Page displays correct radio button options for DVA and DVLA
+        Given I see the radio button for DVLA
+        Then The DVLA Radio button label reads DVLA
+        And The DVLA Hint text reads Trwyddedau gyrru a chyhoeddwyd yng Nghymru, Lloegr a'r Alban.
+        And I see the radio button for DVA
+        Then The DVA Radio button label reads DVA
+        And The DVA Hint text reads Trwyddedau gyrru a chyhoeddwyd yng Ngogledd Iwerddon.
+        And I see the radio button for I do not have a UK photocard driving licence
+        Then The third Radio button label reads Nid oes gennyf drwydded yrru cerdyn-llun y DU
+
+    @mock-api:driving-licence-InvalidRadioSelection @validation-regression
+    Scenario: Driving Licence - Landing Page - There is a problem error displays when no radio button is selected
+        Given I click the continue button without selecting a radio button option
+        Then I see the Error Text Mae problem
+        And I see the Error Summary Text Mae'n rhaid i chi ddewis opsiwn i barhau
+        And I see the Hint Error Summary Text Mae'n rhaid i chi ddewis opsiwn i barhau
+
+    @mock-api:driving-licence-DropDownLink @validation-regression
+    Scenario: Driving Licence - Landing Page Drop Down - 'Why we need to know this'
+        Given I see the Drop Down link for Pam mae angen i ni wybod hyn
+        And User clicks the Drop Down button
+        Then I see the drop down text as Mae angen i ni sicrhau ein bod yn gwirio manylion eich trwydded yrru gyda'r sefydliad cywir.
+
+    @mock-api:driving-licence-Cookies @validation-regression
+    Scenario: Driving Licence - User Clicks the Accept Cookies on the Cookie Banner
+        Given The cookie banner is displayed
+        When User clicks on the Accept Cookie Button
+        Then I see the Cookie Banner Accept text as Rydych wedi derbyn cwcis ychwanegol. Gallwch newid eich gosodiadau cwcis unrhyw bryd.
+        Then User clicks on the Accept Hide this message button
+
+    @mock-api:driving-licence-Cookies @validation-regression
+    Scenario: Driving Licence - User Clicks the Reject Cookies on the Cookie Banner
+        Given The cookie banner is displayed
+        When User clicks on the Reject Cookie Button
+        Then I see the Cookie Banner Reject text as Rydych wedi gwrthod cwcis ychwanegol. Gallwch newid eich gosodiadau cwcis unrhyw bryd.
+        Then User clicks on the Reject Hide this message button
+
+    @mock-api:driving-licence-BetaBanner @validation-regression
+    Scenario: Driving Licence - GOV.UK Beta Banner
+        Given The beta banner is displayed
+        And The beta banner reads Mae hwn yn wasanaeth newydd – bydd eich adborth (agor mewn tab newydd) yn ein helpu i'w wella.
+        When User clicks on the Feedback Link
+        And I check the Feedback page Title Contact GOV.UK One Login
+
+    @mock-api:driving-licence-PageFooter @validation-regression
+    Scenario: Driving Licence - Footer - Accessibility statement
+        Given I see the Accessibility statement footer link with the text Datganiad hygyrchedd
+        When User clicks the Accessibiliy statement Link
+        And I check the Accessibiliy statement page Title Accessibility statement for GOV.UK One Login – GOV.UK One Login
+
+    @mock-api:driving-licence-PageFooter @validation-regression
+    Scenario: Driving Licence - Footer - Cookies
+        Given I see the Cookies footer link with the text Cwcis
+        When User clicks the Cookies Link
+        And I check the Cookies page Title GOV.UK One Login cookies policy – GOV.UK One Login
+
+    @mock-api:driving-licence-PageFooter @validation-regression
+    Scenario: Driving Licence - Footer - Terms and Conditions
+        Given I see the Terms and conditions footer link with the text Telerau ac amodau
+        When User clicks the Terms and conditions Link
+        And I check the Terms and conditions page Title GOV.UK One Login terms and conditions – GOV.UK One Login
+
+    @mock-api:driving-licence-PageFooter @validation-regression
+    Scenario: Driving Licence - Footer - Privacy Notice
+        Given I see the Privacy notice footer link with the text Hysbysiad preifatrwydd
+        When User clicks the Privacy notice Link
+        And I check the Privacy notice page Title GOV.UK One Login privacy notice – GOV.UK One Login
+
+    @mock-api:driving-licence-PageFooter @validation-regression
+    Scenario: Driving Licence - Footer - Support (opens in new tab)
+        Given I see the Support footer link with the text Cymorth (agor mewn tab newydd)
+        When User clicks the Support Link
+        And I check the Support page Title Contact GOV.UK One Login – GOV.UK One Login
+
+    @mock-api:driving-licence-PageFooter @validation-regression
+    Scenario: Driving Licence - Footer - Crown Copyright
+        Given I see the Crown Copyright footer link with the text © Hawlfraint y goron
+        When User clicks the Crown Copyright Link
+        And I check the Crown Copyright page Title Contact GOV.UK One Login – GOV.UK One Login
+
+    @mock-api:driving-licence-PageFooter @validation-regression
+    Scenario: Driving Licence - Footer - Open Government Licence v3.0
+        Given I see the OGL footer link with the text Mae’r holl gynnwys ar gael o dan Trwydded Llywodraeth Agored v3.0, oni nodir yn wahanol
+        When User clicks the OGL Link
+        And I check the OGL page Title Open Government Licence for public sector information

--- a/test/browser/features/Welsh/DVA/WelshDVA.feature
+++ b/test/browser/features/Welsh/DVA/WelshDVA.feature
@@ -1,5 +1,5 @@
 @mock-api:dl-failed @mock-api:dl-success @success @DVA
-Feature: DVA Driving licence CRI Error Validations
+Feature: DVA Driving licence CRI Error Validations - Welsh Translation
 
   Background:
     Given Authenticatable Anita is using the system

--- a/test/browser/features/Welsh/DVLA/WelshDVLA.feature
+++ b/test/browser/features/Welsh/DVLA/WelshDVLA.feature
@@ -1,5 +1,5 @@
 @mock-api:dl-failed @mock-api:dl-success @success @DVLA
-Feature: DVLA Driving licence CRI Error Validations
+Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
 
   Background:
     Given Authenticatable Anita is using the system

--- a/test/browser/pages/licence-issuer.js
+++ b/test/browser/pages/licence-issuer.js
@@ -7,13 +7,135 @@ module.exports = class PlaywrightDevPage {
   constructor(page) {
     this.page = page;
     this.url = "http://localhost:5030/licence-issuer";
-
     this.radioBtnDVLA = this.page.getByLabel("DVLA");
     this.radioBtnDVA = this.page.getByLabel("DVA");
+    this.radioBtnNoDrivingLicence = this.page.locator(
+      'xpath=//*[@id="licenceIssuer-noLicence"]'
+    );
+    this.CTButton = this.page.locator('xpath=//*[@id="submitButton"]');
+    this.betaBanner = this.page.locator("xpath=/html/body/div[2]/div");
+    this.betaBannerText = this.page.locator(
+      "xpath=/html/body/div[2]/div/p/span"
+    );
+    this.betaBannerFeedbackLink = this.page.locator(
+      "xpath=/html/body/div[2]/div/p/span/a"
+    );
+    this.feedbackPageTitle = this.page.locator(
+      'xpath=//*[@id="main-content"]/div/div/h1'
+    );
+    this.cookieBanner = this.page.locator(
+      'xpath=//*[@id="cookies-banner-main"]'
+    );
+    this.cookieAcceptButton = this.page.locator(
+      'xpath=//*[@id="cookies-banner-main"]/div[2]/button[1]'
+    );
+    this.cookieRejectButton = this.page.locator(
+      'xpath=//*[@id="cookies-banner-main"]/div[2]/button[2]'
+    );
+    this.cookieAcceptedTestDisplayed = this.page.locator(
+      'xpath=//*[@id="cookies-accepted"]/div[1]/div/div/p'
+    );
+    this.cookieRejectedTestDisplayed = this.page.locator(
+      'xpath=//*[@id="cookies-rejected"]/div[1]'
+    );
+    this.hideThisMessageAcceptedButton = this.page.locator(
+      'xpath=//*[@id="cookies-accepted"]/div[2]/a'
+    );
+    this.hideThisMessageRejectedButton = this.page.locator(
+      'xpath=//*[@id="cookies-rejected"]/div[2]/a'
+    );
+    this.viewCookiesLink = this.page.locator(
+      'xpath=//*[@id="cookies-banner-main"]/div[2]/a'
+    );
+    this.cookiesPageTitle = this.page.locator(
+      'xpath=//*[@id="main-content"]/div/div/h1'
+    );
+    this.changeYourCookiesSettingsLink = this.page.locator(
+      'xpath=//*[@id="cookies-accepted"]/div[1]/div/div/p/a'
+    );
+    this.dvlaRadioLabelText = this.page.locator(
+      'xpath=//*[@id="licenceIssuer-DVLA-label"]'
+    );
+    this.dvlaRadioLabelHintText = this.page.locator(
+      'xpath=//*[@id="licenceIssuer-item-hint"]'
+    );
+    this.dvaRadioLabelHintText = this.page.locator(
+      'xpath=//*[@id="licenceIssuer-DVA-item-hint"]'
+    );
+    this.dvaRadioLabelText = this.page.locator(
+      'xpath=//*[@id="licenceIssuer-DVA-label"]'
+    );
+    this.doNotHaveDrivingLicenceRadioLabelText = this.page.locator(
+      'xpath=//*[@id="licenceIssuer-noLicence-label"]'
+    );
+    this.whyWeNeedToSeeThisDropDownLink = this.page.locator(
+      'xpath=//*[@id="main-content"]/div/div/form/details/summary/span'
+    );
+    this.whyWeNeedToSeeThisDropDownText = this.page.locator(
+      'xpath=//*[@id="main-content"]/div/div/form/details/div'
+    );
+    this.accessibilityStatementLink = this.page.locator(
+      "xpath=/html/body/footer/div/div/div[1]/ul/li[1]/a"
+    );
+    this.accessibilityStatementPageTitle = this.page.locator(
+      'xpath=//*[@id="main-content"]/div/div/h1'
+    );
+    this.cookiesLink = this.page.locator(
+      "xpath=/html/body/footer/div/div/div[1]/ul/li[2]/a"
+    );
+    this.termsAndConditionsLink = this.page.locator(
+      "xpath=/html/body/footer/div/div/div[1]/ul/li[3]/a"
+    );
+    this.termsAndConditionsPageTitle = this.page.locator(
+      'xpath=//*[@id="main-content"]/div/div/h1'
+    );
+    this.privacyNoticeLink = this.page.locator(
+      "xpath=/html/body/footer/div/div/div[1]/ul/li[4]/a"
+    );
+    this.privacyNoticePageTitle = this.page.locator(
+      'xpath=//*[@id="main-content"]/div/div/h1'
+    );
+    this.supportLink = this.page.locator(
+      "xpath=/html/body/footer/div/div/div[1]/ul/li[5]/a"
+    );
+    this.supportPageTitle = this.page.locator(
+      'xpath=//*[@id="main-content"]/div/div/h1'
+    );
+    this.crownCopyrightLink = this.page.locator(
+      "xpath=/html/body/footer/div/div/div[2]/a"
+    );
+    this.crownCopyrightPageTitle = this.page.locator(
+      'xpath=//*[@id="primary"]/div/div[1]/div/div/article/div[1]/h1'
+    );
+    this.openGovernmentLicenceLinkText = this.page.locator(
+      "xpath=/html/body/footer/div/div/div[1]/span"
+    );
+    this.openGovernmentLicenceLink = this.page.locator(
+      "xpath=/html/body/footer/div/div/div[1]/span/a"
+    );
+    this.openGovernmentLicencePageTitle = this.page.locator(
+      'xpath=//*[@id="open-licence-logo"]'
+    );
+    this.govUkLink = this.page.locator(
+      "xpath=/html/body/header/div/div/a/span/span"
+    );
+    this.govUkPageTitle = this.page.locator(
+      'xpath=//*[@id="content"]/header/div/div[1]/h1/span[1]'
+    );
+    this.dlLandingPageTitle = this.page.locator('xpath=//*[@id="header"]');
+    this.dlLandingPageTitleSummary = this.page.locator(
+      'xpath=//*[@id="licenceIssuer-hint"]'
+    );
 
-    this.CTButton = this.page.locator("button", {
-      hasText: " Continue "
-    });
+    this.dlLandingPageErrorTitle = this.page.locator(
+      'xpath=//*[@id="main-content"]/div[1]/div/h2'
+    );
+    this.dlLandingPageErrorTitleSummary = this.page.locator(
+      'xpath=//*[@id="main-content"]/div[1]/div/div/ul/li/a'
+    );
+    this.dlLandingPageErrorHintSummary = this.page.locator(
+      'xpath=//*[@id="licenceIssuer-error"]'
+    );
   }
 
   isCurrentPage() {
@@ -38,5 +160,311 @@ module.exports = class PlaywrightDevPage {
     );
     await this.radioBtnDVA.click();
     await this.CTButton.click();
+  }
+
+  async betaBannerDisplayed() {
+    await this.page.waitForLoadState("domcontentloaded");
+    await this.betaBanner.isVisible();
+  }
+
+  async cookieBannerDisplayed() {
+    await this.page.waitForLoadState("domcontentloaded");
+    await this.cookieBanner.isVisible();
+  }
+
+  async clickCookieAcceptButton() {
+    await this.page.waitForLoadState("domcontentloaded");
+    await this.cookieAcceptButton.click();
+  }
+
+  async clickCookieRejectButton() {
+    await this.page.waitForLoadState("domcontentloaded");
+    await this.cookieRejectButton.click();
+  }
+
+  async clickViewCookiesLink() {
+    await this.page.waitForLoadState("domcontentloaded");
+    await this.viewCookiesLink.click();
+  }
+
+  async clickChangeCookieSettingsLink() {
+    await this.page.waitForLoadState("domcontentloaded");
+    await this.page.evaluate(() => {
+      const linkElement = document.querySelector(
+        'div.govuk-cookie-banner__message > a.govuk-link[href="https://signin.account.gov.uk/cookies"]'
+      );
+      if (linkElement) {
+        linkElement.click();
+      }
+    });
+  }
+
+  async selectDVLARadioButton() {
+    await this.page.waitForLoadState("domcontentloaded");
+    await this.radioBtnDVLA.click();
+  }
+
+  async dvlaRadioButtonLabel(firstRadioButton) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(await this.dvlaRadioLabelText.textContent()).to.contains(
+      firstRadioButton
+    );
+  }
+
+  async dvlaRadioButtonLabelHintText(firstRadioButtonHintText) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(await this.dvlaRadioLabelHintText.textContent()).to.contains(
+      firstRadioButtonHintText
+    );
+  }
+
+  async dvaRadioButtonLabelHintText(secondRadioButtonHintText) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(await this.dvaRadioLabelHintText.textContent()).to.contains(
+      secondRadioButtonHintText
+    );
+  }
+
+  async selectDVARadioButton() {
+    await this.page.waitForLoadState("domcontentloaded");
+    await this.radioBtnDVA.click();
+  }
+
+  async dvaRadioButtonLabel(secondRadioButton) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(await this.dvaRadioLabelText.textContent()).to.contains(
+      secondRadioButton
+    );
+  }
+
+  async selectNoDrivingLicenceRadioButton() {
+    await this.page.waitForLoadState("domcontentloaded");
+    await this.radioBtnNoDrivingLicence.click();
+  }
+
+  async noDrivingLicenceRadioButtonLabel(thirdRadioButton) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(
+      await this.doNotHaveDrivingLicenceRadioLabelText.textContent()
+    ).to.contains(thirdRadioButton);
+  }
+
+  async dropDownSummaryLinkText(dropDownSummaryLinkText) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(await this.whyWeNeedToSeeThisDropDownLink.textContent()).to.contains(
+      dropDownSummaryLinkText
+    );
+  }
+
+  async clickDropDownSummaryLink() {
+    await this.page.waitForLoadState("domcontentloaded");
+    await this.whyWeNeedToSeeThisDropDownLink.click();
+  }
+
+  async assertDropDownLinkText(dropDownLinkText) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(await this.whyWeNeedToSeeThisDropDownText.textContent()).to.contains(
+      dropDownLinkText
+    );
+  }
+
+  async assertCookieBannerAcceptText(cookieAcceptSummaryText) {
+    await this.page.waitForLoadState("domcontentloaded");
+    await this.cookieAcceptedTestDisplayed.isVisible(cookieAcceptSummaryText);
+  }
+
+  async assertCookieBannerRejectText(cookieRejectSummaryText) {
+    await this.page.waitForLoadState("domcontentloaded");
+    this.cookieRejectedTestDisplayed.isVisible(cookieRejectSummaryText);
+  }
+
+  async assertBetaBannerText(betaBannerText) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(await this.betaBannerText.innerText()).to.equal(betaBannerText);
+  }
+
+  async clickHideThisMessageCookieButton() {
+    await this.page.waitForLoadState("domcontentloaded");
+    await this.page.evaluate(() => {
+      const hiddenButton = document.querySelector(".cookie-hide-button");
+      if (hiddenButton) {
+        hiddenButton.click();
+      }
+    });
+  }
+
+  async assertCookiesPolicyPageTitle(cookiesPageTitle) {
+    await this.page.waitForLoadState("domcontentloaded");
+    await this.cookiesPageTitle.isVisible(cookiesPageTitle);
+  }
+
+  async assertFeedbackPageTitle(feedbackPageTitle) {
+    await this.page.waitForLoadState("domcontentloaded");
+    await this.feedbackPageTitle.isVisible(feedbackPageTitle);
+  }
+
+  async assertAccessibilityStatementPageTitle(accessibilityStatementPageTitle) {
+    await this.page.waitForLoadState("domcontentloaded");
+    await this.accessibilityStatementPageTitle.isVisible(
+      accessibilityStatementPageTitle
+    );
+  }
+
+  async assertAccessibilityStatementLinkText(accessibilityStatementLinkText) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(await this.accessibilityStatementLink.innerText()).to.equal(
+      accessibilityStatementLinkText
+    );
+  }
+
+  async clickAccessibilityStatementLink() {
+    await this.page.waitForLoadState("domcontentloaded");
+    await this.accessibilityStatementLink.click();
+  }
+
+  async clickBetaBannerFeedbackLink() {
+    await this.page.waitForLoadState("domcontentloaded");
+    await this.betaBannerFeedbackLink.click();
+  }
+
+  async assertCookiesLinkText(cookiesLinkText) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(await this.cookiesLink.innerText()).to.equal(cookiesLinkText);
+  }
+
+  async clickCookiesLink() {
+    await this.page.waitForLoadState("domcontentloaded");
+    await this.cookiesLink.click();
+  }
+
+  async assertTermsAndConditionsLinkText(termsAndConditionsLinkText) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(await this.termsAndConditionsLink.innerText()).to.equal(
+      termsAndConditionsLinkText
+    );
+  }
+
+  async clickTermsAndConditionsLink() {
+    await this.page.waitForLoadState("domcontentloaded");
+    await this.termsAndConditionsLink.click();
+  }
+
+  async assertTermsAndConditionsPageTitle(termsAndConditionsPageTitle) {
+    await this.page.waitForLoadState("domcontentloaded");
+    await this.accessibilityStatementPageTitle.isVisible(
+      termsAndConditionsPageTitle
+    );
+  }
+
+  async assertPrivacyNoticeLinkText(privacyNoticeLinkText) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(await this.privacyNoticeLink.innerText()).to.equal(
+      privacyNoticeLinkText
+    );
+  }
+
+  async clickPrivacyNoticeLink() {
+    await this.page.waitForLoadState("domcontentloaded");
+    await this.privacyNoticeLink.click();
+  }
+
+  async assertPrivacyNoticePageTitle(privacyNoticePageTitle) {
+    await this.page.waitForLoadState("domcontentloaded");
+    await this.privacyNoticePageTitle.isVisible(privacyNoticePageTitle);
+  }
+
+  async assertSupportLinkText(supportLinkText) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(await this.supportLink.innerText()).to.equal(supportLinkText);
+  }
+
+  async clickSupportLink() {
+    await this.page.waitForLoadState("domcontentloaded");
+    await this.supportLink.click();
+  }
+
+  async assertSupportPageTitle(supportPageTitle) {
+    await this.page.waitForLoadState("domcontentloaded");
+    await this.supportPageTitle.isVisible(supportPageTitle);
+  }
+
+  async assertCrownCopyrightLinkText(crownCopyrightLinkText) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(await this.crownCopyrightLink.innerText()).to.equal(
+      crownCopyrightLinkText
+    );
+  }
+
+  async clickCrownCopyrightLink() {
+    await this.page.waitForLoadState("domcontentloaded");
+    await this.crownCopyrightLink.click();
+  }
+
+  async assertCrownCopyrightPageTitle(crownCopyrightPageTitle) {
+    await this.page.waitForLoadState("domcontentloaded");
+    await this.crownCopyrightPageTitle.isVisible(crownCopyrightPageTitle);
+  }
+
+  async assertOpenGovernmentLicenceLinkText(openGovernmentLicenceLinkText) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(await this.openGovernmentLicenceLinkText.innerText()).to.equal(
+      openGovernmentLicenceLinkText
+    );
+  }
+
+  async clickOpenGovernmentLicenceLink() {
+    await this.page.waitForLoadState("domcontentloaded");
+    await this.openGovernmentLicenceLink.click();
+  }
+
+  async assertOpenGovernmentLicencePageTitle(openGovernmentLicencePageTitle) {
+    await this.page.waitForLoadState("domcontentloaded");
+    await this.openGovernmentLicencePageTitle.isVisible(
+      openGovernmentLicencePageTitle
+    );
+  }
+
+  async assertGovUkLinkText(govUkLinkText) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(await this.govUkLink.innerText()).to.equal(govUkLinkText);
+  }
+
+  async clickGovUkLink() {
+    await this.page.waitForLoadState("domcontentloaded");
+    await this.govUkLink.click();
+  }
+
+  async assertGovUkPageTitle(govUkPageTitle) {
+    await this.page.waitForLoadState("domcontentloaded");
+    await this.govUkPageTitle.isVisible(govUkPageTitle);
+  }
+
+  async assertDlLandingPageTitle(dlLandingPageTitle) {
+    await this.page.waitForLoadState("domcontentloaded");
+    await this.dlLandingPageTitle.isVisible(dlLandingPageTitle);
+  }
+
+  async assertDlLandingPageTitleSummary(dlLandingPageTitleSummary) {
+    await this.page.waitForLoadState("domcontentloaded");
+    await this.dlLandingPageTitleSummary.isVisible(dlLandingPageTitleSummary);
+  }
+
+  async assertTitleError(noRadioButtonSelectTitleError) {
+    await this.page.waitForLoadState("domcontentloaded");
+    await this.dlLandingPageErrorTitle.isVisible(noRadioButtonSelectTitleError);
+  }
+
+  async assertTitleErrorSummary(noRadioButtonSelectTitleSummaryError) {
+    await this.page.waitForLoadState("domcontentloaded");
+    await this.dlLandingPageErrorTitleSummary.isVisible(
+      noRadioButtonSelectTitleSummaryError
+    );
+  }
+
+  async assertHintErrorSummary(noRadioButtonSelectHintSummaryError) {
+    await this.page.waitForLoadState("domcontentloaded");
+    await this.dlLandingPageErrorHintSummary.isVisible(
+      noRadioButtonSelectHintSummaryError
+    );
   }
 };

--- a/test/browser/step_definitions/licence-issuer.js
+++ b/test/browser/step_definitions/licence-issuer.js
@@ -1,37 +1,423 @@
 const { Given, When, Then } = require("@cucumber/cucumber");
-
 const { expect } = require("chai");
-
 const { LicenceIssuerPage } = require("../pages");
 
 When(/^they (?:have )?start(?:ed)? the DL journey$/, async function () {});
 
 Given(/they (?:can )?see? the licence-issuer page$/, async function () {
   const licenceIssuerPage = new LicenceIssuerPage(this.page);
-
   expect(licenceIssuerPage.isCurrentPage()).to.be.true;
 });
 
+Given(
+  /^I click the continue button without selecting a radio button option$/,
+  async function () {
+    const licenceIssuerPage = new LicenceIssuerPage(this.page);
+    await licenceIssuerPage.continue();
+  }
+);
+
 Given(/^they (?:have )?continue(?:d)? to DL check$/, async function () {
   const licenceIssuerPage = new LicenceIssuerPage(this.page);
-
   expect(licenceIssuerPage.isCurrentPage()).to.be.true;
-
   await licenceIssuerPage.continue();
 });
 
 Given(/^I click on DVLA radio button and Continue$/, async function () {
   const licenceIssuerPage = new LicenceIssuerPage(this.page);
-
   expect(licenceIssuerPage.isCurrentPage()).to.be.true;
-
   await licenceIssuerPage.clickOnDVLARadioButton();
 });
 
 Given(/^I click on DVA radio button and Continue$/, async function () {
   const licenceIssuerPage = new LicenceIssuerPage(this.page);
-
   expect(licenceIssuerPage.isCurrentPage()).to.be.true;
-
   await licenceIssuerPage.clickOnDVARadioButton();
 });
+
+Given(/^The cookie banner is displayed$/, async function () {
+  const licenceIssuerPage = new LicenceIssuerPage(this.page);
+  await licenceIssuerPage.cookieBannerDisplayed();
+});
+
+Then(
+  /^I check the Cookies page Title (.*)$/,
+  async function (cookiesPageTitle) {
+    const licenceIssuerPage = new LicenceIssuerPage(this.page);
+    await licenceIssuerPage.assertCookiesPolicyPageTitle(cookiesPageTitle);
+  }
+);
+
+Given(/^The beta banner is displayed$/, async function () {
+  const licenceIssuerPage = new LicenceIssuerPage(this.page);
+  await licenceIssuerPage.betaBannerDisplayed();
+});
+
+When(/^User clicks on the Accept Cookie Button$/, async function () {
+  const licenceIssuerPage = new LicenceIssuerPage(this.page);
+  await licenceIssuerPage.clickCookieAcceptButton();
+});
+
+When(/^User clicks on the Reject Cookie Button$/, async function () {
+  const licenceIssuerPage = new LicenceIssuerPage(this.page);
+  await licenceIssuerPage.clickCookieRejectButton();
+});
+
+When(/^User clicks on the View Cookies Link$/, async function () {
+  const licenceIssuerPage = new LicenceIssuerPage(this.page);
+  await licenceIssuerPage.clickViewCookiesLink();
+});
+
+When(/^I see the radio button for DVLA$/, async function () {
+  const licenceIssuerPage = new LicenceIssuerPage(this.page);
+  await licenceIssuerPage.selectDVLARadioButton();
+});
+
+Then(
+  /^The DVLA Radio button label reads (.*)$/,
+  async function (firstRadioButton) {
+    const licenceIssuerPage = new LicenceIssuerPage(this.page);
+    await licenceIssuerPage.dvlaRadioButtonLabel(firstRadioButton);
+  }
+);
+
+Then(
+  /^The DVLA Hint text reads (.*)$/,
+  async function (firstRadioButtonHintText) {
+    const licenceIssuerPage = new LicenceIssuerPage(this.page);
+    await licenceIssuerPage.dvlaRadioButtonLabelHintText(
+      firstRadioButtonHintText
+    );
+  }
+);
+
+Then(
+  /^The DVA Hint text reads (.*)$/,
+  async function (secondRadioButtonHintText) {
+    const licenceIssuerPage = new LicenceIssuerPage(this.page);
+    await licenceIssuerPage.dvaRadioButtonLabelHintText(
+      secondRadioButtonHintText
+    );
+  }
+);
+
+When(/^I see the radio button for DVA$/, async function () {
+  const licenceIssuerPage = new LicenceIssuerPage(this.page);
+  await licenceIssuerPage.selectDVARadioButton();
+});
+
+Then(
+  /^The DVA Radio button label reads (.*)$/,
+  async function (secondRadioButton) {
+    const licenceIssuerPage = new LicenceIssuerPage(this.page);
+    await licenceIssuerPage.dvaRadioButtonLabel(secondRadioButton);
+  }
+);
+
+When(
+  /^I see the radio button for I do not have a UK photocard driving licence$/,
+  async function () {
+    const licenceIssuerPage = new LicenceIssuerPage(this.page);
+    await licenceIssuerPage.selectNoDrivingLicenceRadioButton();
+  }
+);
+
+Then(
+  /^The third Radio button label reads (.*)$/,
+  async function (thirdRadioButton) {
+    const licenceIssuerPage = new LicenceIssuerPage(this.page);
+    await licenceIssuerPage.noDrivingLicenceRadioButtonLabel(thirdRadioButton);
+  }
+);
+
+Then(
+  /^I see the Drop Down link for (.*)$/,
+  async function (dropDownSummaryLinkText) {
+    const licenceIssuerPage = new LicenceIssuerPage(this.page);
+    await licenceIssuerPage.dropDownSummaryLinkText(dropDownSummaryLinkText);
+  }
+);
+
+Then(/^User clicks the Drop Down button$/, async function () {
+  const licenceIssuerPage = new LicenceIssuerPage(this.page);
+  await licenceIssuerPage.clickDropDownSummaryLink();
+});
+
+Then(/^I see the drop down text as (.*)$/, async function (dropDownLinkText) {
+  const licenceIssuerPage = new LicenceIssuerPage(this.page);
+  await licenceIssuerPage.assertDropDownLinkText(dropDownLinkText);
+});
+
+Then(/^User click the change your cookie settings link$/, async function () {
+  const licenceIssuerPage = new LicenceIssuerPage(this.page);
+  await licenceIssuerPage.clickChangeCookieSettingsLink();
+});
+
+Then(
+  /^I see the Cookie Banner Accept text as (.*)$/,
+  async function (cookieAcceptSummaryText) {
+    const licenceIssuerPage = new LicenceIssuerPage(this.page);
+    await licenceIssuerPage.assertCookieBannerAcceptText(
+      cookieAcceptSummaryText
+    );
+  }
+);
+
+Then(
+  /^I see the Cookie Banner Reject text as (.*)$/,
+  async function (cookieRejectSummaryText) {
+    const licenceIssuerPage = new LicenceIssuerPage(this.page);
+    await licenceIssuerPage.assertCookieBannerRejectText(
+      cookieRejectSummaryText
+    );
+  }
+);
+
+Then(/^User clicks on the Accept Hide this message button$/, async function () {
+  const licenceIssuerPage = new LicenceIssuerPage(this.page);
+  await licenceIssuerPage.clickHideThisMessageCookieButton();
+});
+
+Then(/^User clicks on the Reject Hide this message button$/, async function () {
+  const licenceIssuerPage = new LicenceIssuerPage(this.page);
+  await licenceIssuerPage.clickHideThisMessageCookieButton();
+});
+
+Then(/^The beta banner reads (.*)$/, async function (betaBannerText) {
+  const licenceIssuerPage = new LicenceIssuerPage(this.page);
+  await licenceIssuerPage.assertBetaBannerText(betaBannerText);
+});
+
+Then(/^User clicks on the Feedback Link$/, async function () {
+  const licenceIssuerPage = new LicenceIssuerPage(this.page);
+  await licenceIssuerPage.clickBetaBannerFeedbackLink();
+});
+
+Then(
+  /^I check the Feedback page Title (.*)$/,
+  async function (feedbackPageTitle) {
+    const licenceIssuerPage = new LicenceIssuerPage(this.page);
+    await licenceIssuerPage.assertFeedbackPageTitle(feedbackPageTitle);
+  }
+);
+
+Then(
+  /^I see the Accessibility statement footer link with the text (.*)$/,
+  async function (accessibilityStatementLinkText) {
+    const licenceIssuerPage = new LicenceIssuerPage(this.page);
+    await licenceIssuerPage.assertAccessibilityStatementLinkText(
+      accessibilityStatementLinkText
+    );
+  }
+);
+
+Then(/^User clicks the Accessibiliy statement Link$/, async function () {
+  const licenceIssuerPage = new LicenceIssuerPage(this.page);
+  await licenceIssuerPage.clickAccessibilityStatementLink();
+});
+
+Then(
+  /^I check the Accessibiliy statement page Title (.*)$/,
+  async function (accessibilityStatementPageTitle) {
+    const licenceIssuerPage = new LicenceIssuerPage(this.page);
+    await licenceIssuerPage.assertAccessibilityStatementPageTitle(
+      accessibilityStatementPageTitle
+    );
+  }
+);
+
+Then(
+  /^I see the Cookies footer link with the text (.*)$/,
+  async function (cookiesLinkText) {
+    const licenceIssuerPage = new LicenceIssuerPage(this.page);
+    await licenceIssuerPage.assertCookiesLinkText(cookiesLinkText);
+  }
+);
+
+Then(/^User clicks the Cookies Link$/, async function () {
+  const licenceIssuerPage = new LicenceIssuerPage(this.page);
+  await licenceIssuerPage.clickCookiesLink();
+});
+
+Then(
+  /^I see the Terms and conditions footer link with the text (.*)$/,
+  async function (termsAndConditionsLinkText) {
+    const licenceIssuerPage = new LicenceIssuerPage(this.page);
+    await licenceIssuerPage.assertTermsAndConditionsLinkText(
+      termsAndConditionsLinkText
+    );
+  }
+);
+
+Then(/^User clicks the Terms and conditions Link$/, async function () {
+  const licenceIssuerPage = new LicenceIssuerPage(this.page);
+  await licenceIssuerPage.clickTermsAndConditionsLink();
+});
+
+Then(
+  /^I check the Terms and conditions page Title (.*)$/,
+  async function (termsAndConditionsPageTitle) {
+    const licenceIssuerPage = new LicenceIssuerPage(this.page);
+    await licenceIssuerPage.assertTermsAndConditionsPageTitle(
+      termsAndConditionsPageTitle
+    );
+  }
+);
+
+Then(
+  /^I see the Privacy notice footer link with the text (.*)$/,
+  async function (privacyNoticeLinkText) {
+    const licenceIssuerPage = new LicenceIssuerPage(this.page);
+    await licenceIssuerPage.assertPrivacyNoticeLinkText(privacyNoticeLinkText);
+  }
+);
+
+Then(/^User clicks the Privacy notice Link$/, async function () {
+  const licenceIssuerPage = new LicenceIssuerPage(this.page);
+  await licenceIssuerPage.clickPrivacyNoticeLink();
+});
+
+Then(
+  /^I check the Privacy notice page Title (.*)$/,
+  async function (privacyNoticePageTitle) {
+    const licenceIssuerPage = new LicenceIssuerPage(this.page);
+    await licenceIssuerPage.assertPrivacyNoticePageTitle(
+      privacyNoticePageTitle
+    );
+  }
+);
+
+Then(
+  /^I see the Support footer link with the text (.*)$/,
+  async function (supportLinkText) {
+    const licenceIssuerPage = new LicenceIssuerPage(this.page);
+    await licenceIssuerPage.assertSupportLinkText(supportLinkText);
+  }
+);
+
+Then(/^User clicks the Support Link$/, async function () {
+  const licenceIssuerPage = new LicenceIssuerPage(this.page);
+  await licenceIssuerPage.clickSupportLink();
+});
+
+Then(
+  /^I check the Support page Title (.*)$/,
+  async function (supportPageTitle) {
+    const licenceIssuerPage = new LicenceIssuerPage(this.page);
+    await licenceIssuerPage.assertSupportPageTitle(supportPageTitle);
+  }
+);
+
+Then(
+  /^I see the Crown Copyright footer link with the text (.*)$/,
+  async function (crownCopyrightLinkText) {
+    const licenceIssuerPage = new LicenceIssuerPage(this.page);
+    await licenceIssuerPage.assertCrownCopyrightLinkText(
+      crownCopyrightLinkText
+    );
+  }
+);
+
+Then(/^User clicks the Crown Copyright Link$/, async function () {
+  const licenceIssuerPage = new LicenceIssuerPage(this.page);
+  await licenceIssuerPage.clickCrownCopyrightLink();
+});
+
+Then(
+  /^I check the Crown Copyright page Title (.*)$/,
+  async function (crownCopyrightPageTitle) {
+    const licenceIssuerPage = new LicenceIssuerPage(this.page);
+    await licenceIssuerPage.assertCrownCopyrightPageTitle(
+      crownCopyrightPageTitle
+    );
+  }
+);
+
+Then(
+  /^I see the OGL footer link with the text (.*)$/,
+  async function (openGovernmentLicenceLinkText) {
+    const licenceIssuerPage = new LicenceIssuerPage(this.page);
+    await licenceIssuerPage.assertOpenGovernmentLicenceLinkText(
+      openGovernmentLicenceLinkText
+    );
+  }
+);
+
+Then(/^User clicks the OGL Link$/, async function () {
+  const licenceIssuerPage = new LicenceIssuerPage(this.page);
+  await licenceIssuerPage.clickOpenGovernmentLicenceLink();
+});
+
+Then(
+  /^I check the OGL page Title (.*)$/,
+  async function (openGovernmentLicencePageTitle) {
+    const licenceIssuerPage = new LicenceIssuerPage(this.page);
+    await licenceIssuerPage.assertOpenGovernmentLicencePageTitle(
+      openGovernmentLicencePageTitle
+    );
+  }
+);
+
+Then(
+  /^I see the GOV.UK footer link with the text (.*)$/,
+  async function (govUkLinkText) {
+    const licenceIssuerPage = new LicenceIssuerPage(this.page);
+    await licenceIssuerPage.assertGovUkLinkText(govUkLinkText);
+  }
+);
+
+Then(/^User clicks the GOV.UK Link$/, async function () {
+  const licenceIssuerPage = new LicenceIssuerPage(this.page);
+  await licenceIssuerPage.clickGovUkLink();
+});
+
+Then(/^I check the GOV.UK page Title (.*)$/, async function (govUkPageTitle) {
+  const licenceIssuerPage = new LicenceIssuerPage(this.page);
+  await licenceIssuerPage.assertGovUkPageTitle(govUkPageTitle);
+});
+
+Then(
+  /^I should be on the Landing Page with Page Title (.*)$/,
+  async function (dlLandingPageTitle) {
+    const licenceIssuerPage = new LicenceIssuerPage(this.page);
+    await licenceIssuerPage.assertDlLandingPageTitle(dlLandingPageTitle);
+  }
+);
+
+Then(
+  /^I see the Landing Page Title Summary Text (.*)$/,
+  async function (dlLandingPageTitleSummary) {
+    const licenceIssuerPage = new LicenceIssuerPage(this.page);
+    await licenceIssuerPage.assertDlLandingPageTitleSummary(
+      dlLandingPageTitleSummary
+    );
+  }
+);
+
+Then(
+  /^I see the Error Text (.*)$/,
+  async function (noRadioButtonSelectTitleError) {
+    const licenceIssuerPage = new LicenceIssuerPage(this.page);
+    await licenceIssuerPage.assertTitleError(noRadioButtonSelectTitleError);
+  }
+);
+
+Then(
+  /^I see the Error Summary Text (.*)$/,
+  async function (noRadioButtonSelectTitleSummaryError) {
+    const licenceIssuerPage = new LicenceIssuerPage(this.page);
+    await licenceIssuerPage.assertTitleErrorSummary(
+      noRadioButtonSelectTitleSummaryError
+    );
+  }
+);
+
+Then(
+  /^I see the Hint Error Summary Text (.*)$/,
+  async function (noRadioButtonSelectHintSummaryError) {
+    const licenceIssuerPage = new LicenceIssuerPage(this.page);
+    await licenceIssuerPage.assertHintErrorSummary(
+      noRadioButtonSelectHintSummaryError
+    );
+  }
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -832,10 +832,10 @@
     forwarded-parse "^2.1.2"
     pino "^8.20.0"
 
-"@govuk-one-login/frontend-vital-signs@0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@govuk-one-login/frontend-vital-signs/-/frontend-vital-signs-0.1.1.tgz#f69f29be7485242cf80628b207a3d2901c7aff2e"
-  integrity sha512-9Arrv4ePlDorGJu9BEHmDtiTNLyACFRqwupJMfACqRIldyBYTXvjswBTWaeCaurP0j2eGnBS098ReGrUSNj5Hw==
+"@govuk-one-login/frontend-vital-signs@0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@govuk-one-login/frontend-vital-signs/-/frontend-vital-signs-0.1.3.tgz#31225add2eb135b5176094ec2e5165b08c8e5413"
+  integrity sha512-cRzEsicoIGq/l6T07gRXWEeUb9RKY0eq4sa6/2IpZwBlUSDFdwbMMY3IO7BZ+WrOcOlrjuOb0KYfSAO7vu8wGA==
   dependencies:
     pino "^8.20.0"
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

Added new featurefile for common tests
Added tests for landing page headers/ footers/ page content/ page elements

### Why did it change

To reduce the associated need for Common tests on the BE DL Repo

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1530](https://govukverify.atlassian.net/browse/LIME-1530)

### Testing

All Tests passed locally in Dev: 
![image](https://github.com/user-attachments/assets/7d3af711-e179-4dcc-b10a-bb076b6fd3af)


<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1530]: https://govukverify.atlassian.net/browse/LIME-1530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ