### PR TITLE
LIME-1510 Language Toggle: Updated aria-label

### DIFF
--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -7,7 +7,7 @@ govuk:
     tag: beta
     content: This is a new service – your <a href="https://home.account.gov.uk/contact-gov-uk-one-login" class="govuk-link" rel="noopener" target="_blank">feedback (opens in new tab)</a> will help us to improve it.
   languageToggle:
-    ariaLabel: Dewis iaith
+    ariaLabel: Choose Language
     englishLanguage: English
     englishVisuallyHidden: Change to English
     welshLanguage: Cymraeg


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

The aria-label for the language toggle when /check page is in English should also be in English so that English speaking screenreader users receive instructions in a language they understand.

### What changed

Updated aria-label in english locale file

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1510](https://govukverify.atlassian.net/browse/LIME-1510)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1510]: https://govukverify.atlassian.net/browse/LIME-1510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ