### PR TITLE
Updating SonarCube GH Action to avoid deprecation

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -50,7 +50,7 @@ jobs:
         run: yarn run test:browser:ci
       - name: Run sonarcloud scan
         if: ${{ github.actor != 'dependabot[bot]' }}
-        uses: SonarSource/sonarcloud-github-action@master
+        uses: SonarSource/sonarqube-scan-action@v5.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION

## Proposed changes
Bumped the GH Action to use the new SonarCloud GH Action

### What changed
version pin

### Why did it change
Upstream action deprecated

### Issue tracking
https://govukverify.atlassian.net/browse/IPS-1428
