### PR TITLE
LIME-1558 Include H1 in form group

### DIFF
--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -142,7 +142,7 @@ consentCheckbox:
     default: "You must give your consent to continue"
 
 licenceIssuer:
-  hint: "You can find this in section 4c of your driving licence. It will either say DVLA (Driving and vehicle Licensing Agency) or DVA (Driver and Vehicle Agency)."
+  hint: "You can find this in section 4c of your driving licence. It will either say DVLA (Driver and Vehicle Licensing Agency) or DVA (Driver and Vehicle Agency)."
   content: ""
   validation:
     required: You must choose an option to continue
@@ -155,7 +155,7 @@ licenceIssuer:
     DVA:
       label: DVA
       value: DVA
-      hint: "Driving licenses issued in Northern Ireland."
+      hint: "Driving licences issued in Northern Ireland."
       reveal: ""
     or:
       label: or

--- a/src/views/drivingLicence/licence-issuer.html
+++ b/src/views/drivingLicence/licence-issuer.html
@@ -8,16 +8,21 @@
 {% from "hmpo-details/macro.njk" import hmpoDetails %}
 
 {% block mainContent %}
-<h1 id="header" data-page="{{hmpoPageKey}}" class="govuk-heading-l" rel="licenceIssuer">
-    {{ translate("licence-issuer.title") }}
-</h1>
+{% set title = translate("licence-issuer.title") %}
 {% call hmpoForm(ctx, {
     attributes: {
         onsubmit: 'window.disableFormSubmit()'
     }
 }) %}
 {{ hmpoRadios(ctx, {
-id: "licenceIssuer"
+   id: "licenceIssuer",
+   fieldset: {
+        legend: {
+            text: title,
+            isPageHeading: true,
+            classes: "govuk-fieldset__legend--l"
+        }
+    }
 }) }}
 
 {{ govukDetails({

--- a/test/browser/features/English/DLCommon/DLCommon.feature
+++ b/test/browser/features/English/DLCommon/DLCommon.feature
@@ -18,7 +18,7 @@ Feature: Driving licence CRI - Common Tests
         And The DVLA Hint text reads Driving licences issued in England, Scotland and Wales.
         And I see the radio button for DVA
         Then The DVA Radio button label reads DVA
-        And The DVA Hint text reads Driving licenses issued in Northern Ireland.
+        And The DVA Hint text reads Driving licences issued in Northern Ireland.
         And I see the radio button for I do not have a UK photocard driving licence
         Then The third Radio button label reads I do not have a UK photocard driving licence
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

H1 heading for the "Was your UK photocard driving licence issued by DVLA or DVA?" page was not correctly grouped with the form in line with Design System Guidance.

### What changed

H1 Inclusion: The H1 element was placed within the form group.

Legend Markup: The H1 is now marked up as the form legend using <legend> tags for improved semantic structure.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1558](https://govukverify.atlassian.net/browse/LIME-1558)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1558]: https://govukverify.atlassian.net/browse/LIME-1558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ