### PR TITLE
LIME-1508 pageTitle and tests amended

### DIFF
--- a/src/locales/cy/default.yml
+++ b/src/locales/cy/default.yml
@@ -12,7 +12,7 @@ govuk:
     englishVisuallyHidden: Change to English
     welshLanguage: Cymraeg
     welshVisuallyHidden: Newid yr iaith ir Gymraeg
-  serviceName: Profi pwy ydych chi
+  serviceName: " "
   backLink: Yn ôl
   errorSummaryTitle: Mae problem
   error: Gwall

--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -12,7 +12,7 @@ govuk:
     englishVisuallyHidden: Change to English
     welshLanguage: Cymraeg
     welshVisuallyHidden: Newid yr iaith ir Gymraeg
-  serviceName: Prove your identity
+  serviceName: " "
   backLink: Back
   errorSummaryTitle: There is a problem
   error: Error

--- a/src/views/drivingLicence/licence-issuer.html
+++ b/src/views/drivingLicence/licence-issuer.html
@@ -32,7 +32,7 @@
 
 {% block submitButton %}
     {{ hmpoSubmit(ctx, {id: 'submitButton'}) }}
-    
+
 {% endblock %}
 
 {% endcall %}

--- a/test/browser/features/English/DVA/DVA.feature
+++ b/test/browser/features/English/DVA/DVA.feature
@@ -6,7 +6,7 @@ Feature: DVA Driving licence CRI Error Validations
     And they have provided their details
     And they have started the DL journey
     And I click on DVA radio button and Continue
-    And I should be on the DVA details entry page Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK One Login
+    And I should be on the DVA details entry page Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
 
   @mock-api:dva-invalidDrivingLicenceNumber @validation-regression @build @staging
   Scenario Outline: DVA - User enters licence number with less than 8 characters
@@ -15,7 +15,7 @@ Feature: DVA Driving licence CRI Error Validations
     When User clicks on continue
     Then I see the DVA licence number error in the summary as Your licence number should be 8 characters long
     And I can see the DVA licence number error in the field as Your licence number should be 8 characters long
-    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK One Login
+    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
       |DVADrivingLicenceSubject       |InvalidLicenceNumber|
       |DrivingLicenceSubjectHappyBilly|5566778             |
@@ -27,7 +27,7 @@ Feature: DVA Driving licence CRI Error Validations
     When User clicks on continue
     Then I see the DVA licence number error in the summary as Your licence number should not include any symbols or spaces
     And I can see the DVA licence number error in the field as Your licence number should not include any symbols or spaces
-    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK One Login
+    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
       |DVADrivingLicenceSubject       |InvalidLicenceNumber|
       |DrivingLicenceSubjectHappyBilly|55667^&*            |
@@ -40,7 +40,7 @@ Feature: DVA Driving licence CRI Error Validations
     When User clicks on continue
     Then I see the DVA licence number error in the summary as Enter the number exactly as it appears on your driving licence
     And I can see the DVA licence number error in the field as Enter the number exactly as it appears on your driving licence
-    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK One Login
+    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
       |DVADrivingLicenceSubject       |InvalidLicenceNumber|
       |DrivingLicenceSubjectHappyBilly|55667ABC            |
@@ -54,7 +54,7 @@ Feature: DVA Driving licence CRI Error Validations
     When User clicks on continue
     Then I see the postcode error in summary as Your postcode should be between 5 and 7 characters
     And I see the postcode error in field as Your postcode should be between 5 and 7 characters
-    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK One Login
+    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
       |DVADrivingLicenceSubject       |InvalidPostcode   |
       |DrivingLicenceSubjectHappyBilly|E20A              |
@@ -66,7 +66,7 @@ Feature: DVA Driving licence CRI Error Validations
     When User clicks on continue
     Then I see the postcode error in summary as Enter your postcode
     And I see the postcode error in field as Enter your postcode
-    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK One Login
+    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
       |DVADrivingLicenceSubject       |InvalidPostcode   |
       |DrivingLicenceSubjectHappyBilly|                  |
@@ -78,7 +78,7 @@ Feature: DVA Driving licence CRI Error Validations
     When User clicks on continue
     Then I see the postcode error in summary as Enter a UK postcode
     And I see the postcode error in field as Enter a UK postcode
-    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK One Login
+    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
       |DVADrivingLicenceSubject       |InvalidPostcode   |
       |DrivingLicenceSubjectHappyBilly|CA 95128          |
@@ -91,7 +91,7 @@ Feature: DVA Driving licence CRI Error Validations
     When User clicks on continue
     Then I see the postcode error in summary as Your postcode should only include numbers and letters
     And I see the postcode error in field as Your postcode should only include numbers and letters
-    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK One Login
+    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
       |DVADrivingLicenceSubject       |InvalidPostcode   |
       |DrivingLicenceSubjectHappyBilly|NW* ^%G           |
@@ -104,7 +104,7 @@ Feature: DVA Driving licence CRI Error Validations
     When User clicks on continue
     Then I see the postcode error in summary as Your postcode should include numbers and letters
     And I see the postcode error in field as Your postcode should include numbers and letters
-    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK One Login
+    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
       |DVADrivingLicenceSubject       |InvalidPostcode   |
       |DrivingLicenceSubjectHappyBilly|123 456           |
@@ -118,7 +118,7 @@ Feature: DVA Driving licence CRI Error Validations
     When User clicks on continue
     Then I see the Lastname error in the error summary as Enter your last name as it appears on your driving licence
     And I see the Lastname error in the error field as Enter your last name as it appears on your driving licence
-    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK One Login
+    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
       |DVADrivingLicenceSubject       |InvalidLastName |
       |DrivingLicenceSubjectHappyBilly|KYLE123         |
@@ -133,7 +133,7 @@ Feature: DVA Driving licence CRI Error Validations
     When User clicks on continue
     Then I see the Firstname error summary as Enter your first name as it appears on your driving licence
     And I see the Firstname error in the error field as Enter your first name as it appears on your driving licence
-    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK One Login
+    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
       | DVADrivingLicenceSubject        | InvalidFirstName                           |
       | DrivingLicenceSubjectHappyBilly | aasdfghjklasdfghjklasdfghjklasdfghjklasdfg |
@@ -149,7 +149,7 @@ Feature: DVA Driving licence CRI Error Validations
     When User clicks on continue
     Then I see the middlenames error summary as Enter any middle names as they appear on your driving licence
     And I see the middlenames error in the error field as Enter any middle names as they appear on your driving licence
-    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK One Login
+    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
       |DVADrivingLicenceSubject          |InvalidMiddleNames|
       |DrivingLicenceSubjectHappyBilly|SELINA987       |
@@ -165,7 +165,7 @@ Feature: DVA Driving licence CRI Error Validations
     When User clicks on continue
     Then DVA user can see the date of birth error summary as Enter your date of birth as it appears on your driving licence
     And DVA user can see the date of birth error in the field as Enter your date of birth as it appears on your driving licence
-    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK One Login
+    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
       |DVADrivingLicenceSubject       |InvalidDayOfBirth|InvalidMonthOfBirth|InvalidYearOfBirth|
       |DrivingLicenceSubjectHappyBilly|         51      |     71            |         198      |
@@ -182,7 +182,7 @@ Feature: DVA Driving licence CRI Error Validations
     When User clicks on continue
     Then DVA user can see the date of birth error summary as Your date of birth must be in the past
     And DVA user can see the date of birth error in the field as Your date of birth must be in the past
-    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK One Login
+    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
       |DVADrivingLicenceSubject       |InvalidDayOfBirth|InvalidMonthOfBirth|InvalidYearOfBirth|
       |DrivingLicenceSubjectHappyBilly|         10      |     10            |         2042     |
@@ -197,7 +197,7 @@ Feature: DVA Driving licence CRI Error Validations
     When User clicks on continue
     Then I see DVA issue date error in summary as Enter the date as it appears on your driving licence
     And I see DVA invalid issue date field error as Enter the date as it appears on your driving licence
-    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK One Login
+    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
       |DVADrivingLicenceSubject          |InvalidDayOfIssue|InvalidMonthOfIssue|InvalidYearOfIssue|
       |DrivingLicenceSubjectHappyBilly|         AA      |     BB            |         AABC     |
@@ -214,7 +214,7 @@ Feature: DVA Driving licence CRI Error Validations
     When User clicks on continue
     Then I see DVA issue date error in summary as The issue date must be in the past
     And I see DVA issue date error in summary as The issue date must be in the past
-    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK One Login
+    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
       |DVADrivingLicenceSubject          |InvalidDayOfIssue|InvalidMonthOfIssue|InvalidYearOfIssue|
       |DrivingLicenceSubjectHappyBilly|         01      |     10            |         2043     |
@@ -229,7 +229,7 @@ Feature: DVA Driving licence CRI Error Validations
     When User clicks on continue
     Then I can see the valid to date error in the error summary as Enter the date as it appears on your driving licence
     And I can see the Valid to date field error as Enter the date as it appears on your driving licence
-    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK One Login
+    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
       |DVADrivingLicenceSubject          |InvalidValidToDay|InvalidValidToMonth|InvalidValidToYear|
       |DrivingLicenceSubjectHappyBilly|         AA      |     BC            |         AABD     |
@@ -246,7 +246,7 @@ Feature: DVA Driving licence CRI Error Validations
     When User clicks on continue
     Then I can see the valid to date error in the error summary as You cannot use an expired driving licence
     And I can see the Valid to date field error as You cannot use an expired driving licence
-    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK One Login
+    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
       |DVADrivingLicenceSubject       |InvalidValidToDay|InvalidValidToMonth|InvalidValidToYear|
       |DrivingLicenceSubjectHappyBilly|         10      |     01            |         2010     |
@@ -258,7 +258,7 @@ Feature: DVA Driving licence CRI Error Validations
     When User clicks on continue
     Then I can see the DVA consent error summary as You must give your consent to continue
     And I can see the DVA consent error on the checkbox as You must give your consent to continue
-    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK One Login
+    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
       | DVADrivingLicenceSubject        |
       | DrivingLicenceSubjectHappyBilly |

--- a/test/browser/features/English/DVA/DVAAuthSource.feature
+++ b/test/browser/features/English/DVA/DVAAuthSource.feature
@@ -8,25 +8,25 @@ Feature: DVA Driving licence - Auth Source
 
   @mock-api:dl-dva-auth-success @validation-regression @build @staging
   Scenario: DVA Auth Source - User navigates through the Auth Source Journey - Check Your Details Page
-    And I should be on the Driving Licence check your details page Check your UK photocard driving licence details – Prove your identity – GOV.UK One Login
+    And I should be on the Driving Licence check your details page Check your UK photocard driving licence details – GOV.UK One Login
     When I click on the Yes radio button
     Then I click on the Confirm and Continue button
-    And I should be on the DVA consent page We need to check your driving licence details – Prove your identity – GOV.UK One Login
+    And I should be on the DVA consent page We need to check your driving licence details – GOV.UK One Login
     And I click on the DVA consent checkbox
     When I click on the Continue button
 
   @mock-api:dl-dva-auth-success @validation-regression @build @staging
   Scenario: DVA Auth Source - User selects No on the Check Your Details Page
-    And I should be on the Driving Licence check your details page Check your UK photocard driving licence details – Prove your identity – GOV.UK One Login
+    And I should be on the Driving Licence check your details page Check your UK photocard driving licence details – GOV.UK One Login
     When I click on the No radio button
     Then I click on the Confirm and Continue button
 
   @mock-api:dl-dva-auth-success @validation-regression @build @staging
   Scenario: DVA Auth Source - User fails to provide consent on the Consent Page
-    And I should be on the Driving Licence check your details page Check your UK photocard driving licence details – Prove your identity – GOV.UK One Login
+    And I should be on the Driving Licence check your details page Check your UK photocard driving licence details – GOV.UK One Login
     When I click on the Yes radio button
     Then I click on the Confirm and Continue button
-    And I should be on the DVA consent page We need to check your driving licence details – Prove your identity – GOV.UK One Login
+    And I should be on the DVA consent page We need to check your driving licence details – GOV.UK One Login
     When I click on the Continue button
     Then I see the No Consent Error Text You must give your consent to continue
 

--- a/test/browser/features/English/DVLA/DVLA.feature
+++ b/test/browser/features/English/DVLA/DVLA.feature
@@ -6,7 +6,7 @@ Feature: DVLA Driving licence CRI Error Validations
     And they have provided their details
     And they have started the DL journey
     And I click on DVLA radio button and Continue
-    And I should be on the DVLA details entry page Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK One Login
+    And I should be on the DVLA details entry page Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
 
   @mock-api:dl-success @validation-regression @build @staging
   Scenario Outline: DVLA - User enters driving licence number date format and does not match with user's date of birth
@@ -19,7 +19,7 @@ Feature: DVLA Driving licence CRI Error Validations
     And I can see the licence number error in the field as Enter the number exactly as it appears on your driving licence
     Then I see the date of birth error summary as Check you have entered your date of birth correctly
     And  I see the date of birth error in the field as Check you have entered your date of birth correctly
-    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK One Login
+    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
       | DrivingLicenceSubject           | InvalidDayOfBirth | InvalidMonthOfBirth | InvalidYearOfBirth |
       | DrivingLicenceSubjectHappyPeter | 12                | 08                  | 1985               |
@@ -31,7 +31,7 @@ Feature: DVLA Driving licence CRI Error Validations
     When User clicks on continue
     Then I see the licence number error in the summary as Your licence number should be 16 characters long
     And I can see the licence number error in the field as Your licence number should be 16 characters long
-    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK One Login
+    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
       | DrivingLicenceSubject           | InvalidLicenceNumber |
       | DrivingLicenceSubjectHappyPeter | PARKE610112PBF       |
@@ -43,7 +43,7 @@ Feature: DVLA Driving licence CRI Error Validations
     When User clicks on continue
     Then I see the licence number error in the summary as Your licence number should not include any symbols or spaces
     And I can see the licence number error in the field as Your licence number should not include any symbols or spaces
-    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK One Login
+    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
       | DrivingLicenceSubject           | InvalidLicenceNumber |
       | DrivingLicenceSubjectHappyPeter | 12345678901112@@     |
@@ -56,7 +56,7 @@ Feature: DVLA Driving licence CRI Error Validations
     When User clicks on continue
     Then I see the licence number error in the summary as Enter the number exactly as it appears on your driving licence
     And I can see the licence number error in the field as Enter the number exactly as it appears on your driving licence
-    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK One Login
+    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
       | DrivingLicenceSubject           | InvalidLicenceNumber |
       | DrivingLicenceSubjectHappyPeter | 1234567890111213     |
@@ -70,7 +70,7 @@ Feature: DVLA Driving licence CRI Error Validations
     When User clicks on continue
     Then I see the issue number error in summary as Your issue number should be 2 numbers long
     And I see the issue number error in field as Your issue number should be 2 numbers long
-    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK One Login
+    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
       | DrivingLicenceSubject           | InvalidIssueNumber |
       | DrivingLicenceSubjectHappyPeter | 1                  |
@@ -82,7 +82,7 @@ Feature: DVLA Driving licence CRI Error Validations
     When User clicks on continue
     Then I see the issue number error in summary as Your issue number should not include any symbols or spaces
     And I see the issue number error in field as Your issue number should not include any symbols or spaces
-    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK One Login
+    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
       | DrivingLicenceSubject           | InvalidIssueNumber |
       | DrivingLicenceSubjectHappyPeter | A@                 |
@@ -95,7 +95,7 @@ Feature: DVLA Driving licence CRI Error Validations
     When User clicks on continue
     Then I see the issue number error in summary as Enter the issue number as it appears on your driving licence
     And I see the issue number error in field as Enter the issue number as it appears on your driving licence
-    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK One Login
+    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
       | DrivingLicenceSubject           | InvalidIssueNumber |
       | DrivingLicenceSubjectHappyPeter | A1                 |
@@ -109,7 +109,7 @@ Feature: DVLA Driving licence CRI Error Validations
     When User clicks on continue
     Then I see the postcode error in summary as Your postcode should be between 5 and 7 characters
     And I see the postcode error in field as Your postcode should be between 5 and 7 characters
-    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK One Login
+    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
       | DrivingLicenceSubject           | InvalidPostcode |
       | DrivingLicenceSubjectHappyPeter | E20A            |
@@ -121,7 +121,7 @@ Feature: DVLA Driving licence CRI Error Validations
     When User clicks on continue
     Then I see the postcode error in summary as Enter your postcode
     And I see the postcode error in field as Enter your postcode
-    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK One Login
+    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
       | DrivingLicenceSubject           | InvalidPostcode |
       | DrivingLicenceSubjectHappyPeter |                 |
@@ -133,7 +133,7 @@ Feature: DVLA Driving licence CRI Error Validations
     When User clicks on continue
     Then I see the postcode error in summary as Enter a UK postcode
     And I see the postcode error in field as Enter a UK postcode
-    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK One Login
+    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
       | DrivingLicenceSubject           | InvalidPostcode |
       | DrivingLicenceSubjectHappyPeter | CA 95128        |
@@ -146,7 +146,7 @@ Feature: DVLA Driving licence CRI Error Validations
     When User clicks on continue
     Then I see the postcode error in summary as Your postcode should only include numbers and letters
     And I see the postcode error in field as Your postcode should only include numbers and letters
-    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK One Login
+    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
       | DrivingLicenceSubject           | InvalidPostcode |
       | DrivingLicenceSubjectHappyPeter | NW* ^%G         |
@@ -159,7 +159,7 @@ Feature: DVLA Driving licence CRI Error Validations
     When User clicks on continue
     Then I see the postcode error in summary as Your postcode should include numbers and letters
     And I see the postcode error in field as Your postcode should include numbers and letters
-    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK One Login
+    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
       | DrivingLicenceSubject           | InvalidPostcode |
       | DrivingLicenceSubjectHappyPeter | 123 456         |
@@ -173,7 +173,7 @@ Feature: DVLA Driving licence CRI Error Validations
     When User clicks on continue
     Then I see the Lastname error in the error summary as Enter your last name as it appears on your driving licence
     And I see the Lastname error in the error field as Enter your last name as it appears on your driving licence
-    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK One Login
+    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
       | DrivingLicenceSubject           | InvalidLastName |
       | DrivingLicenceSubjectHappyPeter | KYLE123         |
@@ -188,7 +188,7 @@ Feature: DVLA Driving licence CRI Error Validations
     When User clicks on continue
     Then I see the Firstname error summary as Enter your first name as it appears on your driving licence
     And I see the Firstname error in the error field as Enter your first name as it appears on your driving licence
-    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK One Login
+    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
       | DrivingLicenceSubject           | InvalidFirstName |
       | DrivingLicenceSubjectHappyPeter | SELINA987        |
@@ -203,7 +203,7 @@ Feature: DVLA Driving licence CRI Error Validations
     When User clicks on continue
     Then I see the middlenames error summary as Enter any middle names as they appear on your driving licence
     And I see the middlenames error in the error field as Enter any middle names as they appear on your driving licence
-    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK One Login
+    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
       | DrivingLicenceSubject           | InvalidMiddleNames |
       | DrivingLicenceSubjectHappyPeter | SELINA987          |
@@ -219,7 +219,7 @@ Feature: DVLA Driving licence CRI Error Validations
     When User clicks on continue
     Then I see the date of birth error summary as Enter your date of birth as it appears on your driving licence
     And I see the date of birth error in the field as Enter your date of birth as it appears on your driving licence
-    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK One Login
+    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
       | DrivingLicenceSubject           | InvalidDayOfBirth | InvalidMonthOfBirth | InvalidYearOfBirth |
       | DrivingLicenceSubjectHappyPeter | @                 | *&                  | 19 7               |
@@ -237,7 +237,7 @@ Feature: DVLA Driving licence CRI Error Validations
     When User clicks on continue
     Then I see the date of birth error summary as Your date of birth must be in the past
     And I see the date of birth error in the field as Your date of birth must be in the past
-    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK One Login
+    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
       | DrivingLicenceSubject           | InvalidDayOfBirth | InvalidMonthOfBirth | InvalidYearOfBirth |
       | DrivingLicenceSubjectHappyPeter | 10                | 10                  | 2042               |
@@ -252,7 +252,7 @@ Feature: DVLA Driving licence CRI Error Validations
     When User clicks on continue
     Then I see issue date error in summary as Enter the date as it appears on your driving licence
     And I see invalid issue date field error as Enter the date as it appears on your driving licence
-    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK One Login
+    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
       | DrivingLicenceSubject           | InvalidDayOfIssue | InvalidMonthOfIssue | InvalidYearOfIssue |
       | DrivingLicenceSubjectHappyPeter | AA                | BB                  | AABC               |
@@ -282,7 +282,7 @@ Feature: DVLA Driving licence CRI Error Validations
     When User clicks on continue
     Then I see issue date error in summary as Enter the date as it appears on your driving licence
     And I see invalid issue date field error as Enter the date as it appears on your driving licence
-    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK One Login
+    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
 
   @mock-api:dl-success @validation-regression @build @staging
   Scenario: DVLA - User enters issue date exactly 10 years old
@@ -309,7 +309,7 @@ Feature: DVLA Driving licence CRI Error Validations
     When User clicks on continue
     Then I see issue date error in summary as The issue date must be in the past
     And I see invalid issue date field error as The issue date must be in the past
-    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK One Login
+    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
       | DrivingLicenceSubject           | InvalidDayOfIssue | InvalidMonthOfIssue | InvalidYearOfIssue |
       | DrivingLicenceSubjectHappyPeter | 01                | 10                  | 2043               |
@@ -324,7 +324,7 @@ Feature: DVLA Driving licence CRI Error Validations
     When User clicks on continue
     Then I can see the valid to date error in the error summary as Enter the date as it appears on your driving licence
     And I can see the Valid to date field error as Enter the date as it appears on your driving licence
-    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK One Login
+    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
       | DrivingLicenceSubject           | InvalidValidToDay | InvalidValidToMonth | InvalidValidToYear |
       | DrivingLicenceSubjectHappyPeter | AA                | BC                  | AABD               |
@@ -341,7 +341,7 @@ Feature: DVLA Driving licence CRI Error Validations
     When User clicks on continue
     Then I can see the valid to date error in the error summary as You cannot use an expired driving licence
     And I can see the Valid to date field error as You cannot use an expired driving licence
-    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK One Login
+    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
       | DrivingLicenceSubject           | InvalidValidToDay | InvalidValidToMonth | InvalidValidToYear |
       | DrivingLicenceSubjectHappyPeter | 10                | 01                  | 2010               |
@@ -353,7 +353,7 @@ Feature: DVLA Driving licence CRI Error Validations
     When User clicks on continue
     And I can see the DVLA consent error on the checkbox as You must give your consent to continue
     Then I can see the DVLA consent error summary as You must give your consent to continue
-    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK One Login
+    And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
       | DrivingLicenceSubject           |
       | DrivingLicenceSubjectHappyPeter |

--- a/test/browser/features/English/DVLA/DVLAAuthSource.feature
+++ b/test/browser/features/English/DVLA/DVLAAuthSource.feature
@@ -8,25 +8,25 @@ Feature: DVLA Driving licence - Auth Source
 
     @mock-api:dl-dvla-auth-success @validation-regression @build @staging
     Scenario: DVLA Auth Source - User navigates through the Auth Source Journey - Check Your Details Page
-        And I should be on the Driving Licence check your details page Check your UK photocard driving licence details – Prove your identity – GOV.UK One Login
+        And I should be on the Driving Licence check your details page Check your UK photocard driving licence details – GOV.UK One Login
         When I click on the Yes radio button
         Then I click on the Confirm and Continue button
-        And I should be on the DVLA consent page We need to check your driving licence details – Prove your identity – GOV.UK One Login
+        And I should be on the DVLA consent page We need to check your driving licence details – GOV.UK One Login
         And I click on the DVLA consent checkbox
         When I click on the Continue button
 
     @mock-api:dl-dvla-auth-success @validation-regression @build @staging
     Scenario: DVLA Auth Source - User selects No on the Check Your Details Page
-        And I should be on the Driving Licence check your details page Check your UK photocard driving licence details – Prove your identity – GOV.UK One Login
+        And I should be on the Driving Licence check your details page Check your UK photocard driving licence details – GOV.UK One Login
         When I click on the No radio button
         Then I click on the Confirm and Continue button
 
     @mock-api:dl-dvla-auth-success @validation-regression @build @staging
     Scenario: DVLA Auth Source - User fails to provide consent on the Consent Page
-        And I should be on the Driving Licence check your details page Check your UK photocard driving licence details – Prove your identity – GOV.UK One Login
+        And I should be on the Driving Licence check your details page Check your UK photocard driving licence details – GOV.UK One Login
         When I click on the Yes radio button
         Then I click on the Confirm and Continue button
-        And I should be on the DVLA consent page We need to check your driving licence details – Prove your identity – GOV.UK One Login
+        And I should be on the DVLA consent page We need to check your driving licence details – GOV.UK One Login
         When I click on the Continue button
         Then I see the No Consent Error Text You must give your consent to continue
 

--- a/test/browser/features/Welsh/DVA/WelshDVA.feature
+++ b/test/browser/features/Welsh/DVA/WelshDVA.feature
@@ -10,7 +10,7 @@ Feature: DVA Driving licence CRI Error Validations - Welsh Translation
 
   @mock-api:dva-PageHeading @language-regression
   Scenario:User Selects DVA and landed in DVA page and Page title and sub-text
-    Given I check the page title Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – Profi pwy ydych chi – GOV.UK One Login
+    Given I check the page title Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
     Then I see the heading Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru
     And I see sentence Os nad oes gennych drwydded yrru y DU neu os na allwch gofio'ch manylion, gallwch brofi pwy ydych chi mewn ffordd arall yn lle.
 
@@ -89,7 +89,7 @@ Feature: DVA Driving licence CRI Error Validations - Welsh Translation
     When User clicks on continue
     Then I see the DVA licence number error in the summary as Dylai rhif eich trwydded fod yn 8 nod o hyd
     And I can see the DVA licence number error in the field as Dylai rhif eich trwydded fod yn 8 nod o hyd
-    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – Profi pwy ydych chi – GOV.UK One Login
+    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
     Examples:
       |DVADrivingLicenceSubject       |InvalidLicenceNumber|
       |DrivingLicenceSubjectHappyBilly|5566778             |
@@ -101,7 +101,7 @@ Feature: DVA Driving licence CRI Error Validations - Welsh Translation
     When User clicks on continue
     Then I see the DVA licence number error in the summary as Ni ddylai rhif eich trwydded gynnwys unrhyw symbolau neu ofodau
     And I can see the DVA licence number error in the field as Ni ddylai rhif eich trwydded gynnwys unrhyw symbolau neu ofodau
-    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – Profi pwy ydych chi – GOV.UK One Login
+    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
     Examples:
       |DVADrivingLicenceSubject       |InvalidLicenceNumber|
       |DrivingLicenceSubjectHappyBilly|55667^&*            |
@@ -114,7 +114,7 @@ Feature: DVA Driving licence CRI Error Validations - Welsh Translation
     When User clicks on continue
     Then I see the DVA licence number error in the summary as Rhowch y rhif yn union fel mae’n ymddangos ar eich trwydded yrru
     And I can see the DVA licence number error in the field as Rhowch y rhif yn union fel mae’n ymddangos ar eich trwydded yrru
-    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – Profi pwy ydych chi – GOV.UK One Login
+    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
     Examples:
       |DVADrivingLicenceSubject       |InvalidLicenceNumber|
 #      |DrivingLicenceSubjectHappyBilly|55667ABC            | - bug raised
@@ -128,7 +128,7 @@ Feature: DVA Driving licence CRI Error Validations - Welsh Translation
     When User clicks on continue
     Then I see the postcode error in summary as Dylai eich rhowch eich cod post fod rhwng 5 a 7 nod
     And I see the postcode error in field as Dylai eich rhowch eich cod post fod rhwng 5 a 7 nod
-    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – Profi pwy ydych chi – GOV.UK One Login
+    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
     Examples:
       |DVADrivingLicenceSubject       |InvalidPostcode   |
       |DrivingLicenceSubjectHappyBilly|E20A              |
@@ -140,7 +140,7 @@ Feature: DVA Driving licence CRI Error Validations - Welsh Translation
     When User clicks on continue
     Then I see the postcode error in summary as Rhowch eich cod post
     And I see the postcode error in field as Rhowch eich cod post
-    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – Profi pwy ydych chi – GOV.UK One Login
+    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
     Examples:
       |DVADrivingLicenceSubject       |InvalidPostcode   |
       |DrivingLicenceSubjectHappyBilly|                  |
@@ -152,7 +152,7 @@ Feature: DVA Driving licence CRI Error Validations - Welsh Translation
     When User clicks on continue
     Then I see the postcode error in summary as Rhowch god post yn y DU
     And I see the postcode error in field as Rhowch god post yn y DU
-    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – Profi pwy ydych chi – GOV.UK One Login
+    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
     Examples:
       |DVADrivingLicenceSubject       |InvalidPostcode   |
       |DrivingLicenceSubjectHappyBilly|CA 95128          |
@@ -165,7 +165,7 @@ Feature: DVA Driving licence CRI Error Validations - Welsh Translation
     When User clicks on continue
     Then I see the postcode error in summary as Dylai eich rhowch eich cod post ond cynnwys rhifau a llythrennau yn unig
     And I see the postcode error in field as Dylai eich rhowch eich cod post ond cynnwys rhifau a llythrennau yn unig
-    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – Profi pwy ydych chi – GOV.UK One Login
+    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
     Examples:
       |DVADrivingLicenceSubject       |InvalidPostcode   |
       |DrivingLicenceSubjectHappyBilly|NW* ^%G           |
@@ -178,7 +178,7 @@ Feature: DVA Driving licence CRI Error Validations - Welsh Translation
     When User clicks on continue
     Then I see the postcode error in summary as Dylai eich rhowch eich cod post ond cynnwys rhifau a llythrennau
     And I see the postcode error in field as Dylai eich rhowch eich cod post ond cynnwys rhifau a llythrennau
-    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – Profi pwy ydych chi – GOV.UK One Login
+    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
     Examples:
       |DVADrivingLicenceSubject       |InvalidPostcode   |
      # |DrivingLicenceSubjectHappyBilly|123 456          |  Bug raised -LIME-750
@@ -192,7 +192,7 @@ Feature: DVA Driving licence CRI Error Validations - Welsh Translation
     When User clicks on continue
     Then I see the Lastname error in the error summary as Rhowch eich enw olaf fel y mae'n ymddangos ar eich trwydded yrru
     And I see the Lastname error in the error field as Rhowch eich enw olaf fel y mae'n ymddangos ar eich trwydded yrru
-    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – Profi pwy ydych chi – GOV.UK One Login
+    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
     Examples:
       |DVADrivingLicenceSubject       |InvalidLastName |
       |DrivingLicenceSubjectHappyBilly|KYLE123         |
@@ -207,7 +207,7 @@ Feature: DVA Driving licence CRI Error Validations - Welsh Translation
     When User clicks on continue
     Then I see the Firstname error summary as Rhowch eich enw cyntaf fel y mae'n ymddangos ar eich trwydded yrru
     And I see the Firstname error in the error field as Rhowch eich enw cyntaf fel y mae'n ymddangos ar eich trwydded yrru
-    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – Profi pwy ydych chi – GOV.UK One Login
+    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
     Examples:
       |DVADrivingLicenceSubject       |InvalidFirstName|
       |DrivingLicenceSubjectHappyBilly|SELINA987       |
@@ -222,7 +222,7 @@ Feature: DVA Driving licence CRI Error Validations - Welsh Translation
     When User clicks on continue
     Then I see the middlenames error summary as Rhowch unrhyw enwau canol fel y maent yn ymddangos ar eich trwydded yrru
     And I see the middlenames error in the error field as Rhowch unrhyw enwau canol fel y maent yn ymddangos ar eich trwydded yrru
-    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – Profi pwy ydych chi – GOV.UK One Login
+    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
     Examples:
       |DVADrivingLicenceSubject          |InvalidMiddleNames|
       |DrivingLicenceSubjectHappyBilly|SELINA987       |
@@ -238,7 +238,7 @@ Feature: DVA Driving licence CRI Error Validations - Welsh Translation
     When User clicks on continue
     Then DVA user can see the date of birth error summary as Rhowch eich dyddiad geni fel y mae'n ymddangos ar eich trwydded yrru
     And DVA user can see the date of birth error in the field as Rhowch eich dyddiad geni fel y mae'n ymddangos ar eich trwydded yrru
-    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – Profi pwy ydych chi – GOV.UK One Login
+    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
     Examples:
       |DVADrivingLicenceSubject       |InvalidDayOfBirth|InvalidMonthOfBirth|InvalidYearOfBirth|
       |DrivingLicenceSubjectHappyBilly|         51      |     71            |         198      |
@@ -254,7 +254,7 @@ Feature: DVA Driving licence CRI Error Validations - Welsh Translation
     When User clicks on continue
     Then DVA user can see the date of birth error summary as Rhaid i'ch dyddiad geni fod yn y gorffennol
     And DVA user can see the date of birth error in the field as Rhaid i'ch dyddiad geni fod yn y gorffennol
-    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – Profi pwy ydych chi – GOV.UK One Login
+    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
     Examples:
       |DVADrivingLicenceSubject       |InvalidDayOfBirth|InvalidMonthOfBirth|InvalidYearOfBirth|
       |DrivingLicenceSubjectHappyBilly|         10      |     10            |         2042     |
@@ -269,7 +269,7 @@ Feature: DVA Driving licence CRI Error Validations - Welsh Translation
     When User clicks on continue
     Then I see DVA issue date error in summary as Rhowch y dyddiad fel y mae'n ymddangos ar eich trwydded yrru
     And I see DVA invalid issue date field error as Rhowch y dyddiad fel y mae'n ymddangos ar eich trwydded yrru
-    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – Profi pwy ydych chi – GOV.UK One Login
+    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
     Examples:
       |DVADrivingLicenceSubject          |InvalidDayOfIssue|InvalidMonthOfIssue|InvalidYearOfIssue|
       |DrivingLicenceSubjectHappyBilly|         AA      |     BB            |         AABC     |
@@ -285,7 +285,7 @@ Feature: DVA Driving licence CRI Error Validations - Welsh Translation
     When User clicks on continue
     Then I see DVA issue date error in summary as Rhaid i ddyddiad cyhoeddi fod yn y gorffennol
     And I see DVA issue date error in summary as Rhaid i ddyddiad cyhoeddi fod yn y gorffennol
-    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – Profi pwy ydych chi – GOV.UK One Login
+    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
     Examples:
       |DVADrivingLicenceSubject          |InvalidDayOfIssue|InvalidMonthOfIssue|InvalidYearOfIssue|
       |DrivingLicenceSubjectHappyBilly|         01      |     10            |         2043     |
@@ -300,7 +300,7 @@ Feature: DVA Driving licence CRI Error Validations - Welsh Translation
     When User clicks on continue
     Then I can see the valid to date error in the error summary as Rhowch y dyddiad fel y mae'n ymddangos ar eich trwydded yrru
     And I can see the Valid to date field error as Rhowch y dyddiad fel y mae'n ymddangos ar eich trwydded yrru
-    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – Profi pwy ydych chi – GOV.UK One Login
+    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
     Examples:
       |DVADrivingLicenceSubject          |InvalidValidToDay|InvalidValidToMonth|InvalidValidToYear|
       |DrivingLicenceSubjectHappyBilly|         AA      |     BC            |         AABD     |
@@ -316,7 +316,7 @@ Feature: DVA Driving licence CRI Error Validations - Welsh Translation
     When User clicks on continue
     Then I can see the valid to date error in the error summary as Ni allwch ddefnyddio trwydded yrru sydd wedi dod i ben
     And I can see the Valid to date field error as Ni allwch ddefnyddio trwydded yrru sydd wedi dod i ben
-    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – Profi pwy ydych chi – GOV.UK One Login
+    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
     Examples:
       |DVADrivingLicenceSubject       |InvalidValidToDay|InvalidValidToMonth|InvalidValidToYear|
       |DrivingLicenceSubjectHappyBilly|         10      |     01            |         2010     |
@@ -328,7 +328,7 @@ Feature: DVA Driving licence CRI Error Validations - Welsh Translation
     When User clicks on continue
     Then I can see the DVA consent error summary as Mae'n rhaid i chi roi eich caniatâd i barhau
     And I can see the DVA consent error on the checkbox as Mae'n rhaid i chi roi eich caniatâd i barhau
-    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – Profi pwy ydych chi – GOV.UK One Login
+    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
     Examples:
       |DVADrivingLicenceSubject             |
       |DrivingLicenceSubjectHappyBilly|

--- a/test/browser/features/Welsh/DVA/WelshDVAAuthSource.feature
+++ b/test/browser/features/Welsh/DVA/WelshDVAAuthSource.feature
@@ -9,13 +9,13 @@ Feature: DVA Driving licence - Auth Source - Welsh Translation
 
     @mock-api:dl-dva-auth-success @language-regression
     Scenario: DVA Auth Source - Welsh Translation Tests - Check Your Answers Page
-        And I should be on the Driving Licence check your details page Gwirio manylion eich trwydded yrru cerdyn-llun yn y DU – Profi pwy ydych chi – GOV.UK One Login
+        And I should be on the Driving Licence check your details page Gwirio manylion eich trwydded yrru cerdyn-llun yn y DU – GOV.UK One Login
 
     @mock-api:dl-dva-auth-success @language-regression
     Scenario: DVA Auth Source - Welsh Translation Tests - Consent Page
         When I click on the Yes radio button
         Then I click on the Confirm and Continue button
-        And I should be on the DVA consent page Rydym angen gwirio manylion eich trwydded yrru – Profi pwy ydych chi – GOV.UK One Login
+        And I should be on the DVA consent page Rydym angen gwirio manylion eich trwydded yrru – GOV.UK One Login
         And I click on the DVA consent checkbox
         When I click on the Continue button
 
@@ -55,6 +55,6 @@ Feature: DVA Driving licence - Auth Source - Welsh Translation
     Scenario: DVA Auth Source - Welsh Translation Tests - Consent Page Text
         When I click on the Yes radio button
         Then I click on the Confirm and Continue button
-        And I should be on the DVA consent page Rydym angen gwirio manylion eich trwydded yrru – Profi pwy ydych chi – GOV.UK One Login
+        And I should be on the DVA consent page Rydym angen gwirio manylion eich trwydded yrru – GOV.UK One Login
         And I can see the consent page title as Rydym angen gwirio manylion eich trwydded yrru gyda'r DVA
         And I can see the consent page text as Caniatau DVA i wirio eich manylion trwydded yrru

--- a/test/browser/features/Welsh/DVLA/WelshDVLA.feature
+++ b/test/browser/features/Welsh/DVLA/WelshDVLA.feature
@@ -10,7 +10,7 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
 
   @mock-api:dvla-PageHeading @language-regression
   Scenario:User Selects DVLA and landed in DVLA page and Page title and sub-text
-    Given I check the page title Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – Profi pwy ydych chi – GOV.UK One Login
+    Given I check the page title Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
     Then I see the heading Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru
     And I see sentence Os nad oes gennych drwydded yrru y DU neu os na allwch gofio'ch manylion, gallwch brofi pwy ydych chi mewn ffordd arall yn lle.
 
@@ -99,7 +99,7 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
     And I can see the licence number error in the field as Rhowch y rhif yn union fel mae’n ymddangos ar eich trwydded yrru
     Then I see the date of birth error summary as Gwiriwch eich bod wedi rhoi eich dyddiad geni yn gywir
     And  I see the date of birth error in the field as Gwiriwch eich bod wedi rhoi eich dyddiad geni yn gywir
-    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – Profi pwy ydych chi – GOV.UK One Login
+    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
     Examples:
       |DrivingLicenceSubject          |InvalidDayOfBirth|InvalidMonthOfBirth|InvalidYearOfBirth|
       |DrivingLicenceSubjectHappyPeter|         12      |     08            |       1985       |
@@ -112,7 +112,7 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
     When User clicks on continue
     Then I see the Lastname error in the error summary as Rhowch eich enw olaf fel y mae'n ymddangos ar eich trwydded yrru
     And I see the Lastname error in the error field as Rhowch eich enw olaf fel y mae'n ymddangos ar eich trwydded yrru
-    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – Profi pwy ydych chi – GOV.UK One Login
+    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
     Examples:
       |DrivingLicenceSubject          |InvalidLastName |
       |DrivingLicenceSubjectHappyPeter|KYLE123         |
@@ -127,7 +127,7 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
     When User clicks on continue
     Then I see the Firstname error summary as Rhowch eich enw cyntaf fel y mae'n ymddangos ar eich trwydded yrru
     And I see the Firstname error in the error field as Rhowch eich enw cyntaf fel y mae'n ymddangos ar eich trwydded yrru
-    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – Profi pwy ydych chi – GOV.UK One Login
+    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
     Examples:
       |DrivingLicenceSubject          |InvalidFirstName|
       |DrivingLicenceSubjectHappyPeter|SELINA987       |
@@ -142,7 +142,7 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
     When User clicks on continue
     Then I see the middlenames error summary as Rhowch unrhyw enwau canol fel y maent yn ymddangos ar eich trwydded yrru
     And I see the middlenames error in the error field as Rhowch unrhyw enwau canol fel y maent yn ymddangos ar eich trwydded yrru
-    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – Profi pwy ydych chi – GOV.UK One Login
+    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
     Examples:
       |DrivingLicenceSubject          |InvalidMiddleNames|
       |DrivingLicenceSubjectHappyPeter|SELINA987         |
@@ -158,7 +158,7 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
     When User clicks on continue
     Then I see the date of birth error summary as Rhowch eich dyddiad geni fel y mae'n ymddangos ar eich trwydded yrru
     And I see the date of birth error in the field as Rhowch eich dyddiad geni fel y mae'n ymddangos ar eich trwydded yrru
-    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – Profi pwy ydych chi – GOV.UK One Login
+    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
     Examples:
       |DrivingLicenceSubject          |InvalidDayOfBirth|InvalidMonthOfBirth|InvalidYearOfBirth|
       |DrivingLicenceSubjectHappyPeter|         @       |     *&            |       19 7     |
@@ -175,7 +175,7 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
     When User clicks on continue
     Then I see the date of birth error summary as Rhaid i'ch dyddiad geni fod yn y gorffennol
     And I see the date of birth error in the field as Rhaid i'ch dyddiad geni fod yn y gorffennol
-    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – Profi pwy ydych chi – GOV.UK One Login
+    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
     Examples:
       |DrivingLicenceSubject          |InvalidDayOfBirth|InvalidMonthOfBirth|InvalidYearOfBirth|
       |DrivingLicenceSubjectHappyPeter|         10      |     10            |         2042     |
@@ -190,7 +190,7 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
     When User clicks on continue
     Then I see issue date error in summary as Rhowch y dyddiad fel y mae'n ymddangos ar eich trwydded yrru
     And I see invalid issue date field error as Rhowch y dyddiad fel y mae'n ymddangos ar eich trwydded yrru
-    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – Profi pwy ydych chi – GOV.UK One Login
+    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
 
     Examples:
       |DrivingLicenceSubject          |InvalidDayOfIssue|InvalidMonthOfIssue|InvalidYearOfIssue|
@@ -207,7 +207,7 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
     When User clicks on continue
     Then I see issue date error in summary as Rhaid i ddyddiad cyhoeddi fod yn y gorffennol
     And I see invalid issue date field error as Rhaid i ddyddiad cyhoeddi fod yn y gorffennol
-    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – Profi pwy ydych chi – GOV.UK One Login
+    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
     Examples:
       |DrivingLicenceSubject          |InvalidDayOfIssue|InvalidMonthOfIssue|InvalidYearOfIssue|
       |DrivingLicenceSubjectHappyPeter|         01      |     10            |         2043     |
@@ -222,7 +222,7 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
     When User clicks on continue
     Then I can see the valid to date error in the error summary as Rhowch y dyddiad fel y mae'n ymddangos ar eich trwydded yrru
     And I can see the Valid to date field error as Rhowch y dyddiad fel y mae'n ymddangos ar eich trwydded yrru
-    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – Profi pwy ydych chi – GOV.UK One Login
+    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
     Examples:
       |DrivingLicenceSubject          |InvalidValidToDay|InvalidValidToMonth|InvalidValidToYear|
       |DrivingLicenceSubjectHappyPeter|         AA      |     BC            |         AABD     |
@@ -238,7 +238,7 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
     When User clicks on continue
     Then I can see the valid to date error in the error summary as Ni allwch ddefnyddio trwydded yrru sydd wedi dod i ben
     And I can see the Valid to date field error as Ni allwch ddefnyddio trwydded yrru sydd wedi dod i ben
-    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – Profi pwy ydych chi – GOV.UK One Login
+    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
     Examples:
       |DrivingLicenceSubject          |InvalidValidToDay|InvalidValidToMonth|InvalidValidToYear|
       |DrivingLicenceSubjectHappyPeter|         10      |     01            |         2010     |
@@ -250,7 +250,7 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
     When User clicks on continue
     Then I see the licence number error in the summary as Dylai rhif eich trwydded fod yn 16 nod o hyd
     And I can see the licence number error in the field as Dylai rhif eich trwydded fod yn 16 nod o hyd
-    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – Profi pwy ydych chi – GOV.UK One Login
+    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
     Examples:
       |DrivingLicenceSubject          |InvalidLicenceNumber|
       |DrivingLicenceSubjectHappyPeter|PARKE610112PBF      |
@@ -262,7 +262,7 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
     When User clicks on continue
     Then I see the licence number error in the summary as Ni ddylai rhif eich trwydded gynnwys unrhyw symbolau neu ofodau
     And I can see the licence number error in the field as Ni ddylai rhif eich trwydded gynnwys unrhyw symbolau neu ofodau
-    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – Profi pwy ydych chi – GOV.UK One Login
+    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
     Examples:
       |DrivingLicenceSubject          |InvalidLicenceNumber|
       |DrivingLicenceSubjectHappyPeter|12345678901112@@    |
@@ -275,7 +275,7 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
     When User clicks on continue
     Then I see the licence number error in the summary as Rhowch y rhif yn union fel mae’n ymddangos ar eich trwydded yrru
     And I can see the licence number error in the field as Rhowch y rhif yn union fel mae’n ymddangos ar eich trwydded yrru
-    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – Profi pwy ydych chi – GOV.UK One Login
+    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
     Examples:
       |DrivingLicenceSubject          |InvalidLicenceNumber|
       |DrivingLicenceSubjectHappyPeter|1234567890111213    |
@@ -289,7 +289,7 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
     When User clicks on continue
     Then I see the issue number error in summary as Dylai eich rhif cyhoeddi fod yn 2 rif o hyd
     And I see the issue number error in field as Dylai eich rhif cyhoeddi fod yn 2 rif o hyd
-    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – Profi pwy ydych chi – GOV.UK One Login
+    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
     Examples:
       |DrivingLicenceSubject          |InvalidIssueNumber|
       |DrivingLicenceSubjectHappyPeter|1                 |
@@ -301,7 +301,7 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
     When User clicks on continue
     Then I see the issue number error in summary as Ni ddylai eich rhif cyhoeddi gynnwys unrhyw symbolau neu ofodau
     And I see the issue number error in field as Ni ddylai eich rhif cyhoeddi gynnwys unrhyw symbolau neu ofodau
-    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – Profi pwy ydych chi – GOV.UK One Login
+    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
     Examples:
       |DrivingLicenceSubject          |InvalidIssueNumber|
       |DrivingLicenceSubjectHappyPeter|A@                |
@@ -314,7 +314,7 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
     When User clicks on continue
     Then I see the issue number error in summary as Rhowch y rhif cyhoeddi fel y mae'n ymddangos ar eich trwydded yrru
     And I see the issue number error in field as Rhowch y rhif cyhoeddi fel y mae'n ymddangos ar eich trwydded yrru
-    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – Profi pwy ydych chi – GOV.UK One Login
+    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
     Examples:
       |DrivingLicenceSubject          |InvalidIssueNumber|
 #     |DrivingLicenceSubjectHappyPeter|A1                |bug raised -LIME-751
@@ -328,7 +328,7 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
     When User clicks on continue
     Then I see the postcode error in summary as Dylai eich rhowch eich cod post fod rhwng 5 a 7 nod
     And I see the postcode error in field as Dylai eich rhowch eich cod post fod rhwng 5 a 7 nod
-    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – Profi pwy ydych chi – GOV.UK One Login
+    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
     Examples:
       |DrivingLicenceSubject          |InvalidPostcode   |
       |DrivingLicenceSubjectHappyPeter|E20A              |
@@ -340,7 +340,7 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
     When User clicks on continue
     Then I see the postcode error in summary as Rhowch eich cod post
     And I see the postcode error in field as Rhowch eich cod post
-    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – Profi pwy ydych chi – GOV.UK One Login
+    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
     Examples:
       |DrivingLicenceSubject          |InvalidPostcode   |
       |DrivingLicenceSubjectHappyPeter|                  |
@@ -352,7 +352,7 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
     When User clicks on continue
     Then I see the postcode error in summary as Rhowch god post yn y DU
     And I see the postcode error in field as Rhowch god post yn y DU
-    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – Profi pwy ydych chi – GOV.UK One Login
+    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
     Examples:
       |DrivingLicenceSubject          |InvalidPostcode   |
       |DrivingLicenceSubjectHappyPeter|CA 95128          |
@@ -365,7 +365,7 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
     When User clicks on continue
     Then I see the postcode error in summary as Dylai eich rhowch eich cod post ond cynnwys rhifau a llythrennau yn unig
     And I see the postcode error in field as Dylai eich rhowch eich cod post ond cynnwys rhifau a llythrennau yn unig
-    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – Profi pwy ydych chi – GOV.UK One Login
+    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
     Examples:
       |DrivingLicenceSubject          |InvalidPostcode   |
       |DrivingLicenceSubjectHappyPeter|NW* ^%G           |
@@ -378,7 +378,7 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
     When User clicks on continue
     Then I see the postcode error in summary as Dylai eich rhowch eich cod post ond cynnwys rhifau a llythrennau
     And I see the postcode error in field as Dylai eich rhowch eich cod post ond cynnwys rhifau a llythrennau
-    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – Profi pwy ydych chi – GOV.UK One Login
+    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
     Examples:
       |DrivingLicenceSubject          |InvalidPostcode   |
       #|DrivingLicenceSubjectHappyPeter|123 456           | Bug raised -LIME-750
@@ -392,7 +392,7 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
     When User clicks on continue
     And I can see the DVLA consent error on the checkbox as Mae'n rhaid i chi roi eich caniatâd i barhau
     Then I can see the DVLA consent error summary as Mae'n rhaid i chi roi eich caniatâd i barhau
-    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – Profi pwy ydych chi – GOV.UK One Login
+    And I check the page Title Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
     Examples:
       |DrivingLicenceSubject             |
       |DrivingLicenceSubjectHappyPeter   |

--- a/test/browser/features/Welsh/DVLA/WelshDVLAAuthSource.feature
+++ b/test/browser/features/Welsh/DVLA/WelshDVLAAuthSource.feature
@@ -9,13 +9,13 @@ Feature: DVLA Driving licence - Auth Source - Welsh Translation
 
     @mock-api:dl-dvla-auth-success @language-regression
     Scenario: DVLA Auth Source - Welsh Translation Tests - Check Your Answers Page
-        And I should be on the Driving Licence check your details page Gwirio manylion eich trwydded yrru cerdyn-llun yn y DU – Profi pwy ydych chi – GOV.UK One Login
+        And I should be on the Driving Licence check your details page Gwirio manylion eich trwydded yrru cerdyn-llun yn y DU – GOV.UK One Login
 
     @mock-api:dl-dvla-auth-success @language-regression
     Scenario: DVLA Auth Source - Welsh Translation Tests - Consent Page
         When I click on the Yes radio button
         Then I click on the Confirm and Continue button
-        And I should be on the DVLA consent page Rydym angen gwirio manylion eich trwydded yrru – Profi pwy ydych chi – GOV.UK One Login
+        And I should be on the DVLA consent page Rydym angen gwirio manylion eich trwydded yrru – GOV.UK One Login
         And I click on the DVLA consent checkbox
         When I click on the Continue button
 
@@ -56,6 +56,6 @@ Feature: DVLA Driving licence - Auth Source - Welsh Translation
     Scenario: DVLA Auth Source - Welsh Translation Tests - Consent Page Text
         When I click on the Yes radio button
         Then I click on the Confirm and Continue button
-        And I should be on the DVLA consent page Rydym angen gwirio manylion eich trwydded yrru – Profi pwy ydych chi – GOV.UK One Login
+        And I should be on the DVLA consent page Rydym angen gwirio manylion eich trwydded yrru – GOV.UK One Login
         And I can see the consent page title as Rydym angen gwirio manylion eich trwydded yrru
         And I can see the consent page text as Caniatau DVLA i wirio eich manylion trwydded yrru

--- a/test/browser/pages/licence-issuer.js
+++ b/test/browser/pages/licence-issuer.js
@@ -144,7 +144,7 @@ module.exports = class PlaywrightDevPage {
 
   async clickOnDVLARadioButton() {
     expect(await this.page.title()).to.equal(
-      "Was your UK photocard driving licence issued by DVLA or DVA? – Prove your identity – GOV.UK One Login"
+      "Was your UK photocard driving licence issued by DVLA or DVA? – GOV.UK One Login"
     );
     await this.radioBtnDVLA.click();
     await this.CTButton.click();
@@ -156,7 +156,7 @@ module.exports = class PlaywrightDevPage {
 
   async clickOnDVARadioButton() {
     expect(await this.page.title()).to.equal(
-      "Was your UK photocard driving licence issued by DVLA or DVA? – Prove your identity – GOV.UK One Login"
+      "Was your UK photocard driving licence issued by DVLA or DVA? – GOV.UK One Login"
     );
     await this.radioBtnDVA.click();
     await this.CTButton.click();


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

serviceName amended to remove _"... - Prove your identity" from page tab titles in DL FE. FE tests also updated to reflect this and the removal adding of 'One Login' to the pageTitle suffix brought in by the Common Express update.

### Why did it change

To keep this service in line with other services of the programme and fix failing tests as a result of the Common Express update beyond 10.1.x.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1508](https://govukverify.atlassian.net/browse/LIME-1508)
- [LIME-1591](https://govukverify.atlassian.net/browse/LIME-1591)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1508]: https://govukverify.atlassian.net/browse/LIME-1508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[LIME-1591]: https://govukverify.atlassian.net/browse/LIME-1591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ