### PR TITLE
LIME-1637 - DL FE - Split out Axe Scan into Specific Tests for better visibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "sinon-chai": "3.7.0",
     "uglify-js": "3.19.3",
     "wait-on": "8.0.1",
-    "wiremock": "^2.33.2"
+    "wiremock": "3.12.1"
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "3.731.1",

--- a/test/browser/features/English/DLCommon/DLCommon.feature
+++ b/test/browser/features/English/DLCommon/DLCommon.feature
@@ -123,3 +123,8 @@ Feature: Driving licence CRI - Common Tests
         Examples:
             | DeviceIntelligenceCookieName |
             | di-device-intelligence       |
+
+    @mock-api:driving-licence-Accessibility @validation-regression
+    Scenario: Driving Licence - Axe Accessibility Scan - DL Landing Page
+        Given I should be on the Landing Page with Page Title Was your UK photocard driving licence issued by DVLA or DVA?
+        And I run the Axe Accessibility check against the DL Landing page

--- a/test/browser/features/English/DVA/DVA.feature
+++ b/test/browser/features/English/DVA/DVA.feature
@@ -387,3 +387,14 @@ Feature: DVA Driving licence CRI Error Validations
     Examples:
       | DeviceIntelligenceCookieName |
       | di-device-intelligence       |
+
+  @mock-api:dva-accessibility @validation-regression @build @staging
+  Scenario Outline: DVA - Axe Accessibility Scan - DVA Details Page
+    Given I run the Axe Accessibility check against the DVA Details page
+
+  @mock-api:DVA-success @build @staging
+  Scenario: DVA - Check support link validation
+    Given I delete the session cookie
+    And User clicks on continue
+    Then they should see an error page
+    Then I run the Axe Accessibility check against the DL Error page

--- a/test/browser/features/English/DVA/DVAAuthSource.feature
+++ b/test/browser/features/English/DVA/DVAAuthSource.feature
@@ -30,8 +30,22 @@ Feature: DVA Driving licence - Auth Source
     When I click on the Continue button
     Then I see the No Consent Error Text You must give your consent to continue
 
-    @mock-api:dl-dva-auth-success @validation-regression
-    Scenario: DVLA Auth Source - Formatting Tests - Date fields format values correctly
-        Given I can see the check details formatted dob value as 08 07 1965
-        And I can see the check details formatted issueDate value as 19 04 2018
-        And I can see the check details formatted validTo value as 01 10 2042
+  @mock-api:dl-dva-auth-success @validation-regression
+  Scenario: DVA Auth Source - Formatting Tests - Date fields format values correctly
+    Given I can see the check details formatted dob value as 08 07 1965
+    And I can see the check details formatted issueDate value as 19 04 2018
+    And I can see the check details formatted validTo value as 01 10 2042
+
+  @mock-api:dl-dva-auth-success @validation-regression @accessibility @build @staging
+  Scenario: DVA Auth Source - Axe Accessibility Scan - Driving Licence - Check Your Details Page
+    And I should be on the Driving Licence check your details page Check your UK photocard driving licence details – GOV.UK One Login
+    Then I run the Axe Accessibility check against the Driving Licence check your details page
+
+  @mock-api:dl-dva-auth-success @validation-regression @build @staging
+  Scenario: DVA Auth Source - Axe Accessibility Scan - Driving Licence - Consent Page
+    And I should be on the Driving Licence check your details page Check your UK photocard driving licence details – GOV.UK One Login
+    When I click on the Yes radio button
+    Then I click on the Confirm and Continue button
+    And I should be on the DVA consent page We need to check your driving licence details – GOV.UK One Login
+    And I run the Axe Accessibility check against the Driving Licence Consent page
+    

--- a/test/browser/features/English/DVLA/DVLA.feature
+++ b/test/browser/features/English/DVLA/DVLA.feature
@@ -556,3 +556,7 @@ Feature: DVLA Driving licence CRI Error Validations
     Examples:
       | DeviceIntelligenceCookieName |
       | di-device-intelligence       |
+
+  @mock-api:dvla-accessibility @validation-regression @build @staging
+  Scenario Outline: DVLA - Axe Accessibility Scan - DVLA Details Page
+    Given I run the Axe Accessibility check against the DVLA Details page

--- a/test/browser/features/English/DVLA/DVLAAuthSource.feature
+++ b/test/browser/features/English/DVLA/DVLAAuthSource.feature
@@ -35,3 +35,16 @@ Feature: DVLA Driving licence - Auth Source
         Given I can see the check details formatted dob value as 08 07 1965
         And I can see the check details formatted issueDate value as 22 08 2023
         And I can see the check details formatted validTo value as 27 04 2025
+
+    @mock-api:dl-dvla-auth-success @validation-regression @accessibility @build @staging
+    Scenario: DVLA Auth Source - Axe Accessibility Scan - Driving Licence Check Your Details Page
+        And I should be on the Driving Licence check your details page Check your UK photocard driving licence details – GOV.UK One Login
+        Then I run the Axe Accessibility check against the Driving Licence check your details page
+
+    @mock-api:dl-dvla-auth-success @validation-regression @accessibility @build @staging
+    Scenario: DVLA Auth Source - Axe Accessibility Scan - Driving Licence - Consent Page
+        And I should be on the Driving Licence check your details page Check your UK photocard driving licence details – GOV.UK One Login
+        When I click on the Yes radio button
+        Then I click on the Confirm and Continue button
+        And I should be on the DVA consent page We need to check your driving licence details – GOV.UK One Login
+        And I run the Axe Accessibility check against the Driving Licence Consent page

--- a/test/browser/step_definitions/CheckYourDetailsStepDefs.js
+++ b/test/browser/step_definitions/CheckYourDetailsStepDefs.js
@@ -12,6 +12,12 @@ Then(
     await checkYourDetailsPage.assertCheckYourDetailsPageTitle(
       checkYourDetailsPageTitle
     );
+  }
+);
+
+Then(
+  /^I run the Axe Accessibility check against the Driving Licence check your details page$/,
+  async function () {
     await injectAxe(this.page);
     // Run Axe for WCAG 2.2 AA rules
     const wcagResults = await this.page.evaluate(() => {
@@ -19,7 +25,7 @@ Then(
         runOnly: ["wcag2aa"]
       });
     });
-    expect(wcagResults.violations, "WCAG 2.2 AAA violations found").to.be.empty;
+    expect(wcagResults.violations).to.be.empty;
   }
 );
 

--- a/test/browser/step_definitions/DrivingLicenceStepDefs.js
+++ b/test/browser/step_definitions/DrivingLicenceStepDefs.js
@@ -11,6 +11,12 @@ Then(
   async function (dvlaDetailsEntryPageTitle) {
     const drivingLicencePage = new DrivingLicencePage(this.page);
     await drivingLicencePage.assertDVLAPageTitle(dvlaDetailsEntryPageTitle);
+  }
+);
+
+Then(
+  /^I run the Axe Accessibility check against the DVLA Details page$/,
+  async function () {
     await injectAxe(this.page);
     // Run Axe for WCAG 2.2 AA rules
     const wcagResults = await this.page.evaluate(() => {
@@ -18,7 +24,7 @@ Then(
         runOnly: ["wcag2aa"]
       });
     });
-    expect(wcagResults.violations, "WCAG 2.2 AAA violations found").to.be.empty;
+    expect(wcagResults.violations).to.be.empty;
   }
 );
 
@@ -423,14 +429,20 @@ Then(
   async function (dvaDetailsEntryPageTitle) {
     const dvaDetailsEntryPage = new DVADetailsEntryPage(this.page);
     await dvaDetailsEntryPage.assertDVAPageTitle(dvaDetailsEntryPageTitle);
+  }
+);
+
+Then(
+  /^I run the Axe Accessibility check against the DVA Details page$/,
+  async function () {
     await injectAxe(this.page);
     // Run Axe for WCAG 2.2 AA rules
     const wcagResults = await this.page.evaluate(() => {
       return axe.run({
-        runOnly: ["wcag2aa"]
+        runOnly: ["wcag22aa"]
       });
     });
-    expect(wcagResults.violations, "WCAG 2.2 AAA violations found").to.be.empty;
+    expect(wcagResults.violations).to.be.empty;
   }
 );
 

--- a/test/browser/step_definitions/consent.js
+++ b/test/browser/step_definitions/consent.js
@@ -8,14 +8,6 @@ Then(
   async function (consentPageTitle) {
     const consentPage = new ConsentPage(this.page);
     await consentPage.assertConsentDVAPageTitle(consentPageTitle);
-    await injectAxe(this.page);
-    // Run Axe for WCAG 2.2 AA rules
-    const wcagResults = await this.page.evaluate(() => {
-      return axe.run({
-        runOnly: ["wcag2aa"]
-      });
-    });
-    expect(wcagResults.violations, "WCAG 2.2 AAA violations found").to.be.empty;
   }
 );
 
@@ -24,6 +16,12 @@ Then(
   async function (consentPageTitle) {
     const consentPage = new ConsentPage(this.page);
     await consentPage.assertConsentDVLAPageTitle(consentPageTitle);
+  }
+);
+
+Then(
+  /^I run the Axe Accessibility check against the Driving Licence Consent page$/,
+  async function () {
     await injectAxe(this.page);
     // Run Axe for WCAG 2.2 AA rules
     const wcagResults = await this.page.evaluate(() => {
@@ -31,7 +29,7 @@ Then(
         runOnly: ["wcag2aa"]
       });
     });
-    expect(wcagResults.violations, "WCAG 2.2 AAA violations found").to.be.empty;
+    expect(wcagResults.violations).to.be.empty;
   }
 );
 

--- a/test/browser/step_definitions/errors.js
+++ b/test/browser/step_definitions/errors.js
@@ -1,26 +1,26 @@
 const { Given, When, Then } = require("@cucumber/cucumber");
-
 const { expect } = require("chai");
-
 const { ErrorPage } = require("../pages");
-
 const { injectAxe } = require("axe-playwright");
 
-Then("they should see an error page", async function () {
+Then(/^they should see an error page$/, async function () {
   const errorPage = new ErrorPage(this.page);
-
   const errorTitle = await errorPage.getErrorTitle();
-
-  await injectAxe(this.page);
-  // Run Axe for WCAG 2.2 AA rules
-  const wcagResults = await this.page.evaluate(() => {
-    return axe.run({
-      runOnly: ["wcag2aa"]
-    });
-  });
-  expect(wcagResults.violations, "WCAG 2.2 AAA violations found").to.be.empty;
-
   expect(errorTitle.trim()).to.equal(
     errorPage.getSomethingWentWrongMessage().trim()
   );
 });
+
+Then(
+  /^I run the Axe Accessibility check against the DL Error page$/,
+  async function () {
+    await injectAxe(this.page);
+    // Run Axe for WCAG 2.2 AA rules
+    const wcagResults = await this.page.evaluate(() => {
+      return axe.run({
+        runOnly: ["wcag2aa"]
+      });
+    });
+    expect(wcagResults.violations).to.be.empty;
+  }
+);

--- a/test/browser/step_definitions/licence-issuer.js
+++ b/test/browser/step_definitions/licence-issuer.js
@@ -27,28 +27,12 @@ Given(/^they (?:have )?continue(?:d)? to DL check$/, async function () {
 Given(/^I click on DVLA radio button and Continue$/, async function () {
   const licenceIssuerPage = new LicenceIssuerPage(this.page);
   expect(licenceIssuerPage.isCurrentPage()).to.be.true;
-  await injectAxe(this.page);
-  // Run Axe for WCAG 2.2 AA rules
-  const wcagResults = await this.page.evaluate(() => {
-    return axe.run({
-      runOnly: ["wcag2aa"]
-    });
-  });
-  expect(wcagResults.violations, "WCAG 2.2 AAA violations found").to.be.empty;
   await licenceIssuerPage.clickOnDVLARadioButton();
 });
 
 Given(/^I click on DVA radio button and Continue$/, async function () {
   const licenceIssuerPage = new LicenceIssuerPage(this.page);
   expect(licenceIssuerPage.isCurrentPage()).to.be.true;
-  await injectAxe(this.page);
-  // Run Axe for WCAG 2.2 AA rules
-  const wcagResults = await this.page.evaluate(() => {
-    return axe.run({
-      runOnly: ["wcag2aa"]
-    });
-  });
-  expect(wcagResults.violations, "WCAG 2.2 AAA violations found").to.be.empty;
   await licenceIssuerPage.clickOnDVARadioButton();
 });
 
@@ -409,6 +393,20 @@ Then(
   async function (dlLandingPageTitle) {
     const licenceIssuerPage = new LicenceIssuerPage(this.page);
     await licenceIssuerPage.assertDlLandingPageTitle(dlLandingPageTitle);
+  }
+);
+
+Then(
+  /^I run the Axe Accessibility check against the DL Landing page$/,
+  async function () {
+    await injectAxe(this.page);
+    // Run Axe for WCAG 2.2 AA rules
+    const wcagResults = await this.page.evaluate(() => {
+      return axe.run({
+        runOnly: ["wcag2aa"]
+      });
+    });
+    expect(wcagResults.violations).to.be.empty;
   }
 );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1009,6 +1009,22 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@npmcli/fs@^1.0.0":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@npmcli/fs/-/fs-1.1.1.tgz#72f719fe935e687c56a4faecf3c03d06ba593257"
+  integrity sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==
+  dependencies:
+    "@gar/promisify" "^1.0.1"
+    semver "^7.3.5"
+
+"@npmcli/move-file@^1.0.1":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@npmcli/move-file/-/move-file-1.1.2.tgz#1a82c3e372f7cae9253eb66d72543d6b8685c674"
+  integrity sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==
+  dependencies:
+    mkdirp "^1.0.4"
+    rimraf "^3.0.2"
+
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
@@ -1024,7 +1040,7 @@
   resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.48.2.tgz#87dd40633f980872283404c8142a65744d3f13d6"
   integrity sha512-54w1xCWfXuax7dz4W2M9uw0gDyh+ti/0K/MxcCUxChFh37kkdxPdfZDw5QBbuPUJHr1CiHJ1hXgSs+GgeQc5Zw==
   dependencies:
-    playwright "1.48.2"
+    playwright "1.51.1"
 
 "@redis/bloom@1.2.0":
   version "1.2.0"
@@ -1800,6 +1816,11 @@ acorn-jsx@^5.3.2:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
+acorn@^8.0.3, acorn@^8.8.2:
+  version "8.14.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.14.1.tgz#721d5dc10f7d5b5609a891773d47731796935dfb"
+  integrity sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==
+
 acorn@^8.14.0:
   version "8.14.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.14.0.tgz#063e2c70cac5fb4f6467f0b11152e04c682795b0"
@@ -2236,6 +2257,30 @@ bytes@3.1.2, bytes@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
   integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
+
+cacache@^15.0.5:
+  version "15.3.0"
+  resolved "https://registry.yarnpkg.com/cacache/-/cacache-15.3.0.tgz#dc85380fb2f556fe3dda4c719bfa0ec875a7f1eb"
+  integrity sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==
+  dependencies:
+    "@npmcli/fs" "^1.0.0"
+    "@npmcli/move-file" "^1.0.1"
+    chownr "^2.0.0"
+    fs-minipass "^2.0.0"
+    glob "^7.1.4"
+    infer-owner "^1.0.4"
+    lru-cache "^6.0.0"
+    minipass "^3.1.1"
+    minipass-collect "^1.0.2"
+    minipass-flush "^1.0.5"
+    minipass-pipeline "^1.2.2"
+    mkdirp "^1.0.3"
+    p-map "^4.0.0"
+    promise-inflight "^1.0.1"
+    rimraf "^3.0.2"
+    ssri "^8.0.1"
+    tar "^6.0.2"
+    unique-filename "^1.1.1"
 
 cacheable-lookup@^5.0.3:
   version "5.0.4"
@@ -3524,7 +3569,7 @@ finalhandler@1.3.1:
     statuses "2.0.1"
     unpipe "~1.0.0"
 
-find-cache-dir@^3.2.0:
+find-cache-dir@^3.2.0, find-cache-dir@^3.3.1:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-3.3.2.tgz#b30c5b6eff0730731aea9bbd9dbecbd80256d64b"
   integrity sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==
@@ -3636,6 +3681,13 @@ fromentries@^1.2.0:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/fromentries/-/fromentries-1.3.2.tgz#e4bca6808816bf8f93b52750f1127f5a6fd86e3a"
   integrity sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==
+
+fs-minipass@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-2.1.0.tgz#7f5036fdbf12c63c169190cbe4199c852271f9fb"
+  integrity sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==
+  dependencies:
+    minipass "^3.0.0"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -4190,6 +4242,11 @@ indent-string@^4.0.0:
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
   integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
 
+infer-owner@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/infer-owner/-/infer-owner-1.0.4.tgz#c4cefcaa8e51051c2a40ba2ce8a3d27295af9467"
+  integrity sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==
+
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
@@ -4594,7 +4651,7 @@ json-buffer@3.0.1:
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.1.tgz#9338802a30d3b6605fbe0613e094008ca8c05a13"
   integrity sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==
 
-json-parse-better-errors@^1.0.1:
+json-parse-better-errors@^1.0.1, json-parse-better-errors@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
   integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
@@ -5030,12 +5087,53 @@ minimist@^1.2.8:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
+minipass-collect@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/minipass-collect/-/minipass-collect-1.0.2.tgz#22b813bf745dc6edba2576b940022ad6edc8c617"
+  integrity sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==
+  dependencies:
+    minipass "^3.0.0"
+
+minipass-flush@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/minipass-flush/-/minipass-flush-1.0.5.tgz#82e7135d7e89a50ffe64610a787953c4c4cbb373"
+  integrity sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==
+  dependencies:
+    minipass "^3.0.0"
+
+minipass-pipeline@^1.2.2:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz#68472f79711c084657c067c5c6ad93cddea8214c"
+  integrity sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==
+  dependencies:
+    minipass "^3.0.0"
+
+minipass@^3.0.0, minipass@^3.1.1:
+  version "3.3.6"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.3.6.tgz#7bba384db3a1520d18c9c0e5251c3444e95dd94a"
+  integrity sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==
+  dependencies:
+    yallist "^4.0.0"
+
+minipass@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-5.0.0.tgz#3e9788ffb90b694a5d0ec94479a45b5d8738133d"
+  integrity sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==
+
 "minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.2.tgz#93a9626ce5e5e66bd4db86849e7515e92340a707"
   integrity sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==
 
-mkdirp@^1.0.4:
+minizlib@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.2.tgz#e90d3466ba209b932451508a11ce3d3632145931"
+  integrity sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==
+  dependencies:
+    minipass "^3.0.0"
+    yallist "^4.0.0"
+
+mkdirp@^1.0.3, mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
@@ -5436,6 +5534,13 @@ p-map@^3.0.0:
   dependencies:
     aggregate-error "^3.0.0"
 
+p-map@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-4.0.0.tgz#bb2f95a5eda2ec168ec9274e06a747c3e2904d2b"
+  integrity sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==
+  dependencies:
+    aggregate-error "^3.0.0"
+
 p-try@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
@@ -5638,7 +5743,7 @@ pino@^8.20.0:
     sonic-boom "^3.7.0"
     thread-stream "^2.6.0"
 
-pkg-dir@^4.1.0:
+pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
@@ -5650,10 +5755,10 @@ playwright-core@1.32.3:
   resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.32.3.tgz#e6dc7db0b49e9b6c0b8073c4a2d789a96f519c48"
   integrity sha512-SB+cdrnu74ZIn5Ogh/8278ngEh9NEEV0vR4sJFmK04h2iZpybfbqBY0bX6+BLYWVdV12JLLI+JEFtSnYgR+mWg==
 
-playwright-core@1.48.2:
-  version "1.48.2"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.48.2.tgz#cd76ed8af61690edef5c05c64721c26a8db2f3d7"
-  integrity sha512-sjjw+qrLFlriJo64du+EK0kJgZzoQPsabGF4lBvsid+3CNIZIYLgnMj9V6JY5VhM2Peh20DJWIVpVljLLnlawA==
+playwright-core@1.51.1:
+  version "1.51.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.51.1.tgz#d57f0393e02416f32a47cf82b27533656a8acce1"
+  integrity sha512-/crRMj8+j/Nq5s8QcvegseuyeZPxpQCZb6HNk3Sos3BlZyAknRjoyJPFWkpNn8v0+P3WiwqFF8P+zQo4eqiNuw==
 
 playwright@1.32.3:
   version "1.32.3"
@@ -5662,12 +5767,12 @@ playwright@1.32.3:
   dependencies:
     playwright-core "1.32.3"
 
-playwright@1.48.2:
-  version "1.48.2"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.48.2.tgz#fca45ae8abdc34835c715718072aaff7e305167e"
-  integrity sha512-NjYvYgp4BPmiwfe31j4gHLa3J7bD2WiBz8Lk2RoSsmX38SVIARZ18VYjxLjAcDsAhA+F4iSEXTSGgjua0rrlgQ==
+playwright@1.51.1:
+  version "1.51.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.51.1.tgz#ae1467ee318083968ad28d6990db59f47a55390f"
+  integrity sha512-kkx+MB2KQRkyxjYPc3a0wLZZoDczmppyGJIvQ43l+aZihkaVvmu/21kiyaHeHjiFxjxNNFnUncKmcGIyOojsaw==
   dependencies:
-    playwright-core "1.48.2"
+    playwright-core "1.51.1"
   optionalDependencies:
     fsevents "2.3.2"
 
@@ -5724,6 +5829,11 @@ progress@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
+
+promise-inflight@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
+  integrity sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==
 
 property-expr@^2.0.5:
   version "2.0.6"
@@ -6088,7 +6198,7 @@ rfdc@^1.4.1:
   resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.4.1.tgz#778f76c4fb731d93414e8f925fbecf64cce7f6ca"
   integrity sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==
 
-rimraf@^3.0.0:
+rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
@@ -6222,6 +6332,11 @@ semver@^6.0.0, semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
+
+semver@^7.3.5:
+  version "7.7.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.1.tgz#abd5098d82b18c6c81f6074ff2647fd3e7220c9f"
+  integrity sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==
 
 semver@^7.3.8, semver@^7.5.3, semver@^7.5.4:
   version "7.6.3"
@@ -6444,6 +6559,11 @@ sort-object-keys@^1.1.3:
   resolved "https://registry.yarnpkg.com/sort-object-keys/-/sort-object-keys-1.1.3.tgz#bff833fe85cab147b34742e45863453c1e190b45"
   integrity sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg==
 
+source-list-map@^2.0.0, source-list-map@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
+  integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
+
 "source-map-js@>=0.6.2 <2.0.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.0.tgz#16b809c162517b5b8c3e7dcd315a2a5c2612b2af"
@@ -6457,7 +6577,7 @@ source-map-support@0.5.21, source-map-support@^0.5.21, source-map-support@~0.5.2
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
-source-map@^0.6.0, source-map@^0.6.1:
+source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
@@ -6509,6 +6629,13 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
+
+ssri@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/ssri/-/ssri-8.0.1.tgz#638e4e439e2ffbd2cd289776d5ca457c4f51a2af"
+  integrity sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==
+  dependencies:
+    minipass "^3.1.1"
 
 stackframe@^1.3.4:
   version "1.3.4"
@@ -6635,7 +6762,7 @@ supports-color@^5.3.0, supports-color@^5.5.0:
   dependencies:
     has-flag "^3.0.0"
 
-supports-color@^7.1.0, supports-color@^7.2.0:
+supports-color@^7.0.0, supports-color@^7.1.0, supports-color@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
@@ -6916,6 +7043,20 @@ unicorn-magic@^0.1.0:
   resolved "https://registry.yarnpkg.com/unicorn-magic/-/unicorn-magic-0.1.0.tgz#1bb9a51c823aaf9d73a8bfcd3d1a23dde94b0ce4"
   integrity sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==
 
+unique-filename@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/unique-filename/-/unique-filename-1.1.1.tgz#1d69769369ada0583103a1e6ae87681b56573230"
+  integrity sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==
+  dependencies:
+    unique-slug "^2.0.0"
+
+unique-slug@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/unique-slug/-/unique-slug-2.0.2.tgz#baabce91083fc64e945b0f3ad613e264f7cd4e6c"
+  integrity sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==
+  dependencies:
+    imurmurhash "^0.1.4"
+
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
@@ -7126,10 +7267,10 @@ which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
-wiremock@^2.33.2:
-  version "2.35.1"
-  resolved "https://registry.yarnpkg.com/wiremock/-/wiremock-2.35.1.tgz#45a5cd2c7a50d85744256ae6662397330d5199f1"
-  integrity sha512-GTrJ6Ss9iyqxar3JHrr6PgdRaP5WxwYsKq+zeO2CwE1AOfYZ38s2usjyCXKeDlqtvkKEytHsa9AggPqDvva09Q==
+wiremock@3.12.1:
+  version "3.12.1"
+  resolved "https://registry.yarnpkg.com/wiremock/-/wiremock-3.12.1.tgz#44ff95c8edffeb24c0fd15a7929b9b766a1bc526"
+  integrity sha512-gEJOzFuQTh4emP/bfHPAhL9qLv6LBVn72/jSQKPzNesbp0TT+a/Gx3cSzm0Gc1AGX+WVZ5zFKKemZYMFpqp0mQ==
   dependencies:
     npm-java-runner "^1.0.2"
 


### PR DESCRIPTION
## Proposed changes

Updated Axe Accessibility Tests:

### What changed

Removed the Axe Scan from the background step of the Scenarios and within Error Page Step Added Specific Test for Passport Details Page and Passport Error Page which runs the Axe Scan

### Why did it change

This will allow for clearer reporting and troubleshooting of any accessibility issues going forward

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->




<!-- Describe the changes in detail - the "what"-->



<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1637](https://govukverify.atlassian.net/browse/LIME-1637)

### Other considerations

Test Evidence: 
![image](https://github.com/user-attachments/assets/864a2e74-ee0a-4ed3-af02-b8245356487a)


[LIME-1637]: https://govukverify.atlassian.net/browse/LIME-1637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ