### PR TITLE
LIME-1641 Add Device Intelligence AC Tests to check for Cookie

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -42,6 +42,8 @@ jobs:
           cache: "yarn"
       - name: Install dependencies
         run: yarn install
+      - name: Build dependencies
+        run: yarn build
       - name: Run lint
         run: yarn lint
       - name: Run test and write coverage

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,0 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-yarn lint-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,0 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-yarn test

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "start": "node src/app.js",
-    "start:ci": "NODE_ENV=development API_BASE_URL=http://127.0.0.1:8030/ yarn start",
+    "start:ci": "AUTH_SOURCE_ENABLED=true DEVICE_INTELLIGENCE_ENABLED=true NODE_ENV=development API_BASE_URL=http://127.0.0.1:8030/ yarn start",
     "dev": "LOG_LEVEL=debug nodemon src/app.js",
     "build": "yarn build-sass && yarn build-js && yarn copy-assets",
     "build-sass": "rm -rf dist/public/stylesheets/application.css && sass --no-source-map src/assets/scss/application.scss dist/public/stylesheets/application.css --style compressed",
@@ -25,7 +25,7 @@
     "test:watch": "mocha --watch",
     "mocks": "yarn run wiremock --port 8030 --root-dir test/mocks",
     "test:browser": "mkdir -p reports && wait-on tcp:127.0.0.1:8030 tcp:127.0.0.1:5030 && cucumber-js --config test/browser/cucumber.js",
-    "test:browser:ci": "AUTH_SOURCE_ENABLED=true npm-run-all -p -r start:ci mocks test:browser",
+    "test:browser:ci": "npm-run-all -p -r start:ci mocks test:browser",
     "check-translation": "node node_modules/@govuk-one-login/di-ipv-cri-common-express/scripts/checkTranslations.js '../../../../src/locales'"
   },
   "repository": {

--- a/test/browser/features/English/DLCommon/DLCommon.feature
+++ b/test/browser/features/English/DLCommon/DLCommon.feature
@@ -116,3 +116,10 @@ Feature: Driving licence CRI - Common Tests
         Given I see the OGL footer link with the text All content is available under the Open Government Licence v3.0, except where otherwise stated.
         When User clicks the OGL Link
         And I check the OGL page Title Open Government Licence for public sector information
+
+    @mock-api:driving-licence-PageCookies @validation-regression
+    Scenario: Driving Licence - Cookies - Device Intelligence
+        Given I see the Device Intelligence Cookie <DeviceIntelligenceCookieName>
+        Examples:
+            | DeviceIntelligenceCookieName |
+            | di-device-intelligence       |

--- a/test/browser/features/English/DVA/DVA.feature
+++ b/test/browser/features/English/DVA/DVA.feature
@@ -17,8 +17,8 @@ Feature: DVA Driving licence CRI Error Validations
     And I can see the DVA licence number error in the field as Your licence number should be 8 characters long
     And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
-      |DVADrivingLicenceSubject       |InvalidLicenceNumber|
-      |DrivingLicenceSubjectHappyBilly|5566778             |
+      | DVADrivingLicenceSubject        | InvalidLicenceNumber |
+      | DrivingLicenceSubjectHappyBilly | 5566778              |
 
   @mock-api:dva-invalidDrivingLicenceNumber @validation-regression @build @staging
   Scenario Outline: DVA - User enters licence number with special characters and spaces
@@ -29,10 +29,10 @@ Feature: DVA Driving licence CRI Error Validations
     And I can see the DVA licence number error in the field as Your licence number should not include any symbols or spaces
     And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
-      |DVADrivingLicenceSubject       |InvalidLicenceNumber|
-      |DrivingLicenceSubjectHappyBilly|55667^&*            |
+      | DVADrivingLicenceSubject        | InvalidLicenceNumber |
+      | DrivingLicenceSubjectHappyBilly | 55667^&*             |
 
-###### DrivingLicenceNumberWithAlphaNumericChar, DrivingLicenceNumberWithAlphaChar, NoDrivingLicenceNumber #####
+  ###### DrivingLicenceNumberWithAlphaNumericChar, DrivingLicenceNumberWithAlphaChar, NoDrivingLicenceNumber #####
   @mock-api:dva-invalidDrivingLicenceNumber @validation-regression @build @staging
   Scenario Outline: DVA - User enters licence number with numeric/alpha/null characters
     Given User enters DVA data as a <DVADrivingLicenceSubject>
@@ -42,10 +42,10 @@ Feature: DVA Driving licence CRI Error Validations
     And I can see the DVA licence number error in the field as Enter the number exactly as it appears on your driving licence
     And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
-      |DVADrivingLicenceSubject       |InvalidLicenceNumber|
-      |DrivingLicenceSubjectHappyBilly|55667ABC            |
-      |DrivingLicenceSubjectHappyBilly|XYZabdAB            |
-      |DrivingLicenceSubjectHappyBilly|                    |
+      | DVADrivingLicenceSubject        | InvalidLicenceNumber |
+      | DrivingLicenceSubjectHappyBilly | 55667ABC             |
+      | DrivingLicenceSubjectHappyBilly | XYZabdAB             |
+      | DrivingLicenceSubjectHappyBilly |                      |
 
   @mock-api:dva-invalidPostcode @validation-regression @build @staging
   Scenario Outline: DVA - User enters postcode number with less than 5 characters
@@ -56,8 +56,8 @@ Feature: DVA Driving licence CRI Error Validations
     And I see the postcode error in field as Your postcode should be between 5 and 7 characters
     And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
-      |DVADrivingLicenceSubject       |InvalidPostcode   |
-      |DrivingLicenceSubjectHappyBilly|E20A              |
+      | DVADrivingLicenceSubject        | InvalidPostcode |
+      | DrivingLicenceSubjectHappyBilly | E20A            |
 
   @mock-api:dva-invalidPostcode @validation-regression @build @staging
   Scenario Outline: DVA - User enters no postcode in the postcode field
@@ -68,8 +68,8 @@ Feature: DVA Driving licence CRI Error Validations
     And I see the postcode error in field as Enter your postcode
     And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
-      |DVADrivingLicenceSubject       |InvalidPostcode   |
-      |DrivingLicenceSubjectHappyBilly|                  |
+      | DVADrivingLicenceSubject        | InvalidPostcode |
+      | DrivingLicenceSubjectHappyBilly |                 |
 
   @mock-api:dva-invalidPostcode @validation-regression @build @staging
   Scenario Outline: DVA - User enters international postcode and returns enter a UK postcode error
@@ -80,10 +80,10 @@ Feature: DVA Driving licence CRI Error Validations
     And I see the postcode error in field as Enter a UK postcode
     And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
-      |DVADrivingLicenceSubject       |InvalidPostcode   |
-      |DrivingLicenceSubjectHappyBilly|CA 95128          |
+      | DVADrivingLicenceSubject        | InvalidPostcode |
+      | DrivingLicenceSubjectHappyBilly | CA 95128        |
 
-##### PostcodeWithSpecialChar #####
+  ##### PostcodeWithSpecialChar #####
   @mock-api:dva-invalidPostcode @validation-regression @build @staging
   Scenario Outline: DVA - User enters invalid postcode with special characters
     Given User enters DVA data as a <DVADrivingLicenceSubject>
@@ -93,10 +93,10 @@ Feature: DVA Driving licence CRI Error Validations
     And I see the postcode error in field as Your postcode should only include numbers and letters
     And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
-      |DVADrivingLicenceSubject       |InvalidPostcode   |
-      |DrivingLicenceSubjectHappyBilly|NW* ^%G           |
+      | DVADrivingLicenceSubject        | InvalidPostcode |
+      | DrivingLicenceSubjectHappyBilly | NW* ^%G         |
 
-####### PostcodeWithNumericChar, PostcodeWithAlphaChar #####
+  ####### PostcodeWithNumericChar, PostcodeWithAlphaChar #####
   @mock-api:dva-invalidPostcode @validation-regression @build @staging
   Scenario Outline: DVA - User enters postcode with alpha/numeric characters
     Given User enters DVA data as a <DVADrivingLicenceSubject>
@@ -106,11 +106,11 @@ Feature: DVA Driving licence CRI Error Validations
     And I see the postcode error in field as Your postcode should include numbers and letters
     And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
-      |DVADrivingLicenceSubject       |InvalidPostcode   |
-      |DrivingLicenceSubjectHappyBilly|123 456           |
-      |DrivingLicenceSubjectHappyBilly|ABC XYZ           |
+      | DVADrivingLicenceSubject        | InvalidPostcode |
+      | DrivingLicenceSubjectHappyBilly | 123 456         |
+      | DrivingLicenceSubjectHappyBilly | ABC XYZ         |
 
-######  InvalidLastNameWithNumbers, InvalidLastNameWithSpecialCharacters, NoLastName #####
+  ######  InvalidLastNameWithNumbers, InvalidLastNameWithSpecialCharacters, NoLastName #####
   @mock-api:dva-invalidLastName @validation-regression @build @staging
   Scenario Outline: DVA - User enters last name with alpha/numeric/special/null characters
     Given User enters DVA data as a <DVADrivingLicenceSubject>
@@ -120,12 +120,12 @@ Feature: DVA Driving licence CRI Error Validations
     And I see the Lastname error in the error field as Enter your last name as it appears on your driving licence
     And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
-      |DVADrivingLicenceSubject       |InvalidLastName |
-      |DrivingLicenceSubjectHappyBilly|KYLE123         |
-      |DrivingLicenceSubjectHappyBilly|KYLE^&(         |
-      |DrivingLicenceSubjectHappyBilly|                |
+      | DVADrivingLicenceSubject        | InvalidLastName |
+      | DrivingLicenceSubjectHappyBilly | KYLE123         |
+      | DrivingLicenceSubjectHappyBilly | KYLE^&(         |
+      | DrivingLicenceSubjectHappyBilly |                 |
 
-######  InvalidFirstNameWithNumbers, InvalidFirstNameWithSpecialCharacters, NoFirstName, firstName exceeds maxlength #####
+  ######  InvalidFirstNameWithNumbers, InvalidFirstNameWithSpecialCharacters, NoFirstName, firstName exceeds maxlength #####
   @mock-api:dva-invalidFirstName @validation-regression @build @staging
   Scenario Outline: DVA - User enters first name with alpha/numeric/special/null characters
     Given User enters DVA data as a <DVADrivingLicenceSubject>
@@ -141,7 +141,7 @@ Feature: DVA Driving licence CRI Error Validations
       | DrivingLicenceSubjectHappyBilly | SELINA%$@                                  |
       | DrivingLicenceSubjectHappyBilly |                                            |
 
-#######  InvalidMiddleNamesWithNumbers, InvalidMiddleNamesWithSpecialCharacters #####
+  #######  InvalidMiddleNamesWithNumbers, InvalidMiddleNamesWithSpecialCharacters #####
   @mock-api:dva-invalidMiddleNames @validation-regression @build @staging
   Scenario Outline: DVA - User enters middle nams with alpha/numeric/special/null characters
     Given User enters DVA data as a <DVADrivingLicenceSubject>
@@ -151,11 +151,11 @@ Feature: DVA Driving licence CRI Error Validations
     And I see the middlenames error in the error field as Enter any middle names as they appear on your driving licence
     And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
-      |DVADrivingLicenceSubject          |InvalidMiddleNames|
-      |DrivingLicenceSubjectHappyBilly|SELINA987       |
-      |DrivingLicenceSubjectHappyBilly|SELINA%$@       |
+      | DVADrivingLicenceSubject        | InvalidMiddleNames |
+      | DrivingLicenceSubjectHappyBilly | SELINA987          |
+      | DrivingLicenceSubjectHappyBilly | SELINA%$@          |
 
-#####  DateOfBirthNotReal, DateOfBirthWithSpecialCharacters, NoDateOfBirth #####
+  #####  DateOfBirthNotReal, DateOfBirthWithSpecialCharacters, NoDateOfBirth #####
   @mock-api:dva-invalidDateOfBirth @validation-regression @build @staging
   Scenario Outline: DVA - User enters dob that are not real or with special characters or no issue date error validation or year provided is two digits
     Given User enters DVA data as a <DVADrivingLicenceSubject>
@@ -167,11 +167,11 @@ Feature: DVA Driving licence CRI Error Validations
     And DVA user can see the date of birth error in the field as Enter your date of birth as it appears on your driving licence
     And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
-      |DVADrivingLicenceSubject       |InvalidDayOfBirth|InvalidMonthOfBirth|InvalidYearOfBirth|
-      |DrivingLicenceSubjectHappyBilly|         51      |     71            |         198      |
-      |DrivingLicenceSubjectHappyBilly|         @       |     *&            |         19 7     |
-      |DrivingLicenceSubjectHappyBilly|                 |                   |                  |
-      |DrivingLicenceSubjectHappyBilly|         05      |     12            |         29       |
+      | DVADrivingLicenceSubject        | InvalidDayOfBirth | InvalidMonthOfBirth | InvalidYearOfBirth |
+      | DrivingLicenceSubjectHappyBilly | 51                | 71                  | 198                |
+      | DrivingLicenceSubjectHappyBilly | @                 | *&                  | 19 7               |
+      | DrivingLicenceSubjectHappyBilly |                   |                     |                    |
+      | DrivingLicenceSubjectHappyBilly | 05                | 12                  | 29                 |
 
   @mock-api:dva-invalidDateOfBirth @validation-regression @build @staging
   Scenario Outline: DVA - User enters future date of birth
@@ -184,10 +184,10 @@ Feature: DVA Driving licence CRI Error Validations
     And DVA user can see the date of birth error in the field as Your date of birth must be in the past
     And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
-      |DVADrivingLicenceSubject       |InvalidDayOfBirth|InvalidMonthOfBirth|InvalidYearOfBirth|
-      |DrivingLicenceSubjectHappyBilly|         10      |     10            |         2042     |
+      | DVADrivingLicenceSubject        | InvalidDayOfBirth | InvalidMonthOfBirth | InvalidYearOfBirth |
+      | DrivingLicenceSubjectHappyBilly | 10                | 10                  | 2042               |
 
-#####  IssueDateWithAlphaCharacters, IssueDateWithSpecialCharacters, NoIssueDate #####
+  #####  IssueDateWithAlphaCharacters, IssueDateWithSpecialCharacters, NoIssueDate #####
   @mock-api:dva-invalidIssueDate @validation-regression @build @staging
   Scenario Outline: DVA - User enters issue date that are not real or with special characters or no issue date error validation or year provided is two digits
     Given User enters DVA data as a <DVADrivingLicenceSubject>
@@ -199,11 +199,11 @@ Feature: DVA Driving licence CRI Error Validations
     And I see DVA invalid issue date field error as Enter the date as it appears on your driving licence
     And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
-      |DVADrivingLicenceSubject          |InvalidDayOfIssue|InvalidMonthOfIssue|InvalidYearOfIssue|
-      |DrivingLicenceSubjectHappyBilly|         AA      |     BB            |         AABC     |
-      |DrivingLicenceSubjectHappyBilly|         &       |     ^%            |         £$ ^     |
-      |DrivingLicenceSubjectHappyBilly|                 |                   |                  |
-      |DrivingLicenceSubjectHappyBilly|         05      |     12            |         19       |
+      | DVADrivingLicenceSubject        | InvalidDayOfIssue | InvalidMonthOfIssue | InvalidYearOfIssue |
+      | DrivingLicenceSubjectHappyBilly | AA                | BB                  | AABC               |
+      | DrivingLicenceSubjectHappyBilly | &                 | ^%                  | £$ ^               |
+      | DrivingLicenceSubjectHappyBilly |                   |                     |                    |
+      | DrivingLicenceSubjectHappyBilly | 05                | 12                  | 19                 |
 
   @mock-api:dva-invalidIssueDate @validation-regression @build @staging
   Scenario Outline: DVA - User enters issue date in the future
@@ -216,10 +216,10 @@ Feature: DVA Driving licence CRI Error Validations
     And I see DVA issue date error in summary as The issue date must be in the past
     And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
-      |DVADrivingLicenceSubject          |InvalidDayOfIssue|InvalidMonthOfIssue|InvalidYearOfIssue|
-      |DrivingLicenceSubjectHappyBilly|         01      |     10            |         2043     |
+      | DVADrivingLicenceSubject        | InvalidDayOfIssue | InvalidMonthOfIssue | InvalidYearOfIssue |
+      | DrivingLicenceSubjectHappyBilly | 01                | 10                  | 2043               |
 
-#####  InvalidValidToDate, ValidToDateWithSpecialCharacters, NoValidToDate  #####
+  #####  InvalidValidToDate, ValidToDateWithSpecialCharacters, NoValidToDate  #####
   @mock-api:dva-invalidExpiryDate @validation-regression @build @staging
   Scenario Outline: DVA - User enters valid to dates that are invalid or contain special characters or year provided is two digits or are not real
     Given User enters DVA data as a <DVADrivingLicenceSubject>
@@ -231,11 +231,11 @@ Feature: DVA Driving licence CRI Error Validations
     And I can see the Valid to date field error as Enter the date as it appears on your driving licence
     And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
-      |DVADrivingLicenceSubject          |InvalidValidToDay|InvalidValidToMonth|InvalidValidToYear|
-      |DrivingLicenceSubjectHappyBilly|         AA      |     BC            |         AABD     |
-      |DrivingLicenceSubjectHappyBilly|         !@      |     £$            |         %^ *     |
-      |DrivingLicenceSubjectHappyBilly|                 |                   |                  |
-      |DrivingLicenceSubjectHappyBilly|         05      |     12            |         29       |
+      | DVADrivingLicenceSubject        | InvalidValidToDay | InvalidValidToMonth | InvalidValidToYear |
+      | DrivingLicenceSubjectHappyBilly | AA                | BC                  | AABD               |
+      | DrivingLicenceSubjectHappyBilly | !@                | £$                  | %^ *               |
+      | DrivingLicenceSubjectHappyBilly |                   |                     |                    |
+      | DrivingLicenceSubjectHappyBilly | 05                | 12                  | 29                 |
 
   @mock-api:dva-invalidExpiryDate @validation-regression @build @staging
   Scenario Outline: DVA - User enters valid to date in the past
@@ -248,8 +248,8 @@ Feature: DVA Driving licence CRI Error Validations
     And I can see the Valid to date field error as You cannot use an expired driving licence
     And I check the page Title Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Examples:
-      |DVADrivingLicenceSubject       |InvalidValidToDay|InvalidValidToMonth|InvalidValidToYear|
-      |DrivingLicenceSubjectHappyBilly|         10      |     01            |         2010     |
+      | DVADrivingLicenceSubject        | InvalidValidToDay | InvalidValidToMonth | InvalidValidToYear |
+      | DrivingLicenceSubjectHappyBilly | 10                | 01                  | 2010               |
 
   @mock-api:dva-ConsentError @validation-regression @build @staging
   Scenario Outline: DVA - User attempts journey without selecting consent checkbox
@@ -335,7 +335,7 @@ Feature: DVA Driving licence CRI Error Validations
     Then I see the Firstname error summary as Enter your first name as it appears on your driving licence
     And I see the Firstname error in the error field as Enter your first name as it appears on your driving licence
     Examples:
-      | DVADrivingLicenceSubject        | InvalidFirstName | InvalidMiddleNames |
+      | DVADrivingLicenceSubject        | InvalidFirstName | InvalidMiddleNames  |
       | DrivingLicenceSubjectHappyBilly |                  | abcdefghijklmnopqrs |
 
   @mock-api:dl-success @validation-regression @build @staging
@@ -358,7 +358,7 @@ Feature: DVA Driving licence CRI Error Validations
     Then I see the Firstname error summary as Enter your first name as it appears on your driving licence
     And I see the Firstname error in the error field as Enter your first name as it appears on your driving licence
     Examples:
-      | DVADrivingLicenceSubject        | InvalidLastName           | InvalidFirstName | InvalidMiddleNames                    |
+      | DVADrivingLicenceSubject        | InvalidLastName           | InvalidFirstName | InvalidMiddleNames |
       | DrivingLicenceSubjectHappyBilly | abcdefghijklmnopqrstuvwxy |                  | abcdefghijklmnopqr |
 
   @mock-api:dl-failed @validation-regression @build @staging
@@ -380,3 +380,10 @@ Feature: DVA Driving licence CRI Error Validations
     And I see the DVA Consent second sentence To find out more about how your driving licence details will be used, you can read:
     And I see DVA One Login privacy notice link the GOV.UK One Login privacy notice (opens in a new tab)
     Then I see DVA privacy notice link the DVA privacy notice (opens in a new tab)
+
+  @mock-api:driving-licence-PageCookies @validation-regression
+  Scenario: Driving Licence - Cookies - Device Intelligence
+    Given On the entry details page I see the Device Intelligence Cookie <DeviceIntelligenceCookieName>
+    Examples:
+      | DeviceIntelligenceCookieName |
+      | di-device-intelligence       |

--- a/test/browser/features/English/DVLA/DVLA.feature
+++ b/test/browser/features/English/DVLA/DVLA.feature
@@ -549,3 +549,10 @@ Feature: DVLA Driving licence CRI Error Validations
     And I see the DVLA Consent second sentence To find out more about how your driving licence details will be used, you can read:
     And I see One Login privacy notice link the GOV.UK One Login privacy notice (opens in a new tab)
     Then I see DVLA privacy notice link the DVLA privacy notice (opens in a new tab)
+
+  @mock-api:dl-success @validation-regression @build @staging
+  Scenario: Driving Licence - Cookies - Device Intelligence
+    Given On the entry details page I see the Device Intelligence Cookie <DeviceIntelligenceCookieName>
+    Examples:
+      | DeviceIntelligenceCookieName |
+      | di-device-intelligence       |

--- a/test/browser/pages/DrivingLicencePage.js
+++ b/test/browser/pages/DrivingLicencePage.js
@@ -958,4 +958,34 @@ exports.DrivingLicencePage = class PlaywrightDevPage {
       errorSummaryMessage
     );
   }
+
+  async checkDeviceIntelligenceCookie(deviceIntelligenceCookieName) {
+    // Wait for the page to fully load
+    await this.page.waitForLoadState("networkidle", { timeout: 10000 });
+
+    const cookies = await this.page.context().cookies();
+
+    const cookie = cookies.find(
+      (cookie) => cookie.name === deviceIntelligenceCookieName
+    );
+
+    if (!cookie) {
+      throw new Error(
+        `Cookie with name '${deviceIntelligenceCookieName}' not found.`
+      );
+    }
+
+    if (
+      cookie.value === undefined ||
+      cookie.value === null ||
+      cookie.value.trim() === ""
+    ) {
+      // Check for undefined, null, or empty string in value field of the cookie
+      throw new Error(
+        `Cookie with name '${deviceIntelligenceCookieName}' has no value.`
+      );
+    }
+
+    return true;
+  }
 };

--- a/test/browser/pages/licence-issuer.js
+++ b/test/browser/pages/licence-issuer.js
@@ -467,4 +467,34 @@ module.exports = class PlaywrightDevPage {
       noRadioButtonSelectHintSummaryError
     );
   }
+
+  async checkDeviceIntelligenceCookie(deviceIntelligenceCookieName) {
+    // Wait for the page to fully load
+    await this.page.waitForLoadState("networkidle", { timeout: 10000 });
+
+    const cookies = await this.page.context().cookies();
+
+    const cookie = cookies.find(
+      (cookie) => cookie.name === deviceIntelligenceCookieName
+    );
+
+    if (!cookie) {
+      throw new Error(
+        `Cookie with name '${deviceIntelligenceCookieName}' not found.`
+      );
+    }
+
+    if (
+      cookie.value === undefined ||
+      cookie.value === null ||
+      cookie.value.trim() === ""
+    ) {
+      // Check for undefined, null, or empty string in value field of the cookie
+      throw new Error(
+        `Cookie with name '${deviceIntelligenceCookieName}' has no value.`
+      );
+    }
+
+    return true;
+  }
 };

--- a/test/browser/step_definitions/DrivingLicenceStepDefs.js
+++ b/test/browser/step_definitions/DrivingLicenceStepDefs.js
@@ -922,6 +922,17 @@ Then(
   }
 );
 
+Then(
+  /^On the entry details page I see the Device Intelligence Cookie (.*)$/,
+  async function (deviceIntelligenceCookieName) {
+    const drivingLicencePage = new DrivingLicencePage(this.page);
+
+    await drivingLicencePage.checkDeviceIntelligenceCookie(
+      deviceIntelligenceCookieName
+    );
+  }
+);
+
 //########### Text Content Comparisions - DVA ##############
 
 Then(

--- a/test/browser/step_definitions/licence-issuer.js
+++ b/test/browser/step_definitions/licence-issuer.js
@@ -65,6 +65,17 @@ Then(
   }
 );
 
+Then(
+  /^I see the Device Intelligence Cookie (.*)$/,
+  async function (deviceIntelligenceCookieName) {
+    const licenceIssuerPage = new LicenceIssuerPage(this.page);
+
+    await licenceIssuerPage.checkDeviceIntelligenceCookie(
+      deviceIntelligenceCookieName
+    );
+  }
+);
+
 Given(/^The beta banner is displayed$/, async function () {
   const licenceIssuerPage = new LicenceIssuerPage(this.page);
   await licenceIssuerPage.betaBannerDisplayed();

--- a/yarn.lock
+++ b/yarn.lock
@@ -3268,7 +3268,7 @@ execa@~8.0.1:
     signal-exit "^4.1.0"
     strip-final-newline "^3.0.0"
 
-express-async-errors@^3.1.1:
+express-async-errors@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/express-async-errors/-/express-async-errors-3.1.1.tgz#6053236d61d21ddef4892d6bd1d736889fc9da41"
   integrity sha512-h6aK1da4tpqWSbyCa3FxB/V6Ehd4EEB15zyQq9qe75OZBp0krinNKuH4rAY+S/U/2I36vdLAUFSjQJ+TFmODng==


### PR DESCRIPTION
Added new AC Test to check for device Intelligence cookie and that it has a value

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

New AC Test Added to fraud.feature

### Why did it change

To check that the new device intelligence cookie has been loaded correctly after Fraud Check Page load

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1641](https://govukverify.atlassian.net/browse/LIME-1641)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1641]: https://govukverify.atlassian.net/browse/LIME-1641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ