### PR TITLE
LIME-1665 Replace DLOnlyOneTaskCountAlarm with DLBelowMinTaskCountAlarm so that the alarm is based on the min taskcount of each environment

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1028,10 +1028,10 @@ Resources:
       ComparisonOperator: LessThanThreshold
       TreatMissingData: breaching
 
-  DLOnlyOneTaskCountAlarm:
+  DLBelowMinTaskCountAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmDescription: !Sub Driving Licence ${Environment} frontend below desired ECS service tasks
+      AlarmDescription: !Sub DL ${Environment} frontend below minimum ECS service tasks
       ActionsEnabled: true
       AlarmActions:
         - !Ref AlarmTopicDL
@@ -1047,7 +1047,7 @@ Resources:
       Period: 300
       EvaluationPeriods: 3
       DatapointsToAlarm: 3
-      Threshold: 2
+      Threshold: !FindInMap [EnvironmentConfiguration, !Ref Environment, minECSCount]
       ComparisonOperator: LessThanThreshold
       TreatMissingData: breaching
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

Replace DLOnlyOneTaskCountAlarm with DLBelowMinTaskCountAlarm

### Why did it change

So that the alarm is based on the min taskcount of each environment

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1665](https://govukverify.atlassian.net/browse/LIME-1665)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1665]: https://govukverify.atlassian.net/browse/LIME-1665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ