### PR TITLE
LIME-666: Fixing Incorrect Validation on DVA Welsh Licence Number.

### DIFF
--- a/src/app/drivingLicence/fields.js
+++ b/src/app/drivingLicence/fields.js
@@ -222,7 +222,6 @@ module.exports = {
         type: "regexSpecialCharacters",
         fn: (value) => value.match(/^[A-Za-z0-9]*$/)
       },
-      { type: "numeric" },
       { type: "regexDrivingLicence", fn: (value) => value.match(/^[0-9]{8}$/) }
     ],
     dependent: { field: "issuerDependent", value: "DVA" },

--- a/src/locales/cy/fields.yml
+++ b/src/locales/cy/fields.yml
@@ -16,7 +16,7 @@ dvaLicenceNumber:
   validation:
     default: "Rhowch y rhif yn union fel mae’n ymddangos ar eich trwydded yrru"
     licenceLength: "Dylai rhif eich trwydded fod yn 8 nod o hyd"
-    numeric: "Ni ddylai rhif eich trwydded gynnwys unrhyw symbolau neu ofodau"
+    numeric: "Rhowch y rhif yn union fel mae’n ymddangos ar eich trwydded yrru"
     regexSpecialCharacters: "Ni ddylai rhif eich trwydded gynnwys unrhyw symbolau neu ofodau"
 issueNumber:
   label: Rhif cyhoeddi


### PR DESCRIPTION
### What changed

Fixing the Validation on DVA Welsh Licence Number to return "Rhowch y rhif yn union fel mae'n ymddangos ar eich trwydded yrru" when entering a licence number with an alphanumeric combination (e.g. 123456AA)

### Issue tracking

- [LIME-666](https://govukverify.atlassian.net/browse/LIME-666)


[LIME-666]: https://govukverify.atlassian.net/browse/LIME-666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ