### PR TITLE
LIME-1722: Enable Rebranding in Production.

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -141,7 +141,7 @@ Mappings:
       languageToggleDisabled: "false"
       authSourceEnabled: "true"
       deviceIntelligenceEnabled: "true"
-      may2025RebrandEnabled: "false"
+      may2025RebrandEnabled: "true"
 
   # see https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html
   ElasticLoadBalancerAccountIds:


### PR DESCRIPTION
### What changed

Enable may2025RebrandEnabled in Production.

### Why did it change

To align with the Go Live for Branding Refresh on the 31st July.
