### PR TITLE
LIME-1831 - Update AC tests with coverage for 'Back' Button

### DIFF
--- a/test/browser/features/English/DVA/DVA.feature
+++ b/test/browser/features/English/DVA/DVA.feature
@@ -358,6 +358,12 @@ Feature: DVA Driving licence CRI Error Validations
       | DVADrivingLicenceSubject        | InvalidLastName           | InvalidMiddleNames  |
       | DrivingLicenceSubjectHappyBilly | abcdefghijklmnopqrstuvwxy | abcdefghijklmnopqrs |
 
+  @mock-api:dva-BackButton @validation-regression
+  Scenario: DVA - User clicks the back button
+    Given I see the back button on the DVA details page with text Back
+    And User clicks the back button
+    Then I should be on the Landing Page with Page Title Was your UK photocard driving licence issued by DVLA or DVA?
+
   @mock-api:dva-ConsentSection @validation-regression
   Scenario: DVA - Privacy notice link to consent
     Given I see the consent title section Allow DVA to check your driving licence details

--- a/test/browser/features/English/DVA/DVAAuthSource.feature
+++ b/test/browser/features/English/DVA/DVAAuthSource.feature
@@ -33,6 +33,15 @@ Feature: DVA Driving licence - Auth Source
     And I can see the check details formatted issueDate value as 19 04 2018
     And I can see the check details formatted validTo value as 01 10 2042
 
+  @mock-api:dl-dva-auth-success @validation-regression
+  Scenario: DVA Auth Source - User clicks the back button
+    When I click on the Yes radio button
+    Then I click on the Confirm and Continue button
+    And I should be on the DVA consent page We need to check your driving licence details – GOV.UK One Login
+    Then I see the back button on the DVA check your details page with text Back
+    And User clicks the back button
+    Then I should be on the Driving Licence check your details page Check your UK photocard driving licence details – GOV.UK One Login
+
   @mock-api:dl-dva-auth-success @validation-regression @accessibility
   Scenario: DVA Auth Source - Axe Accessibility Scan - Driving Licence - Check Your Details Page
     Then I run the Axe Accessibility check against the Driving Licence check your details page

--- a/test/browser/features/English/DVLA/DVLA.feature
+++ b/test/browser/features/English/DVLA/DVLA.feature
@@ -548,6 +548,12 @@ Feature: DVLA Driving licence CRI Error Validations
     And I see One Login privacy notice link the GOV.UK One Login privacy notice (opens in a new tab)
     Then I see DVLA privacy notice link the DVLA privacy notice (opens in a new tab)
 
+  @mock-api:dvla-BackButton @validation-regression
+  Scenario: DVLA - User clicks the back button
+    Given I see the back button on the DVLA details page with text Back
+    And User clicks the back button
+    Then I should be on the Landing Page with Page Title Was your UK photocard driving licence issued by DVLA or DVA?
+
   @mock-api:dl-success @cookies
   Scenario: Driving Licence - Cookies - Device Intelligence
     Given On the entry details page I see the Device Intelligence Cookie <DeviceIntelligenceCookieName>

--- a/test/browser/features/English/DVLA/DVLAAuthSource.feature
+++ b/test/browser/features/English/DVLA/DVLAAuthSource.feature
@@ -34,6 +34,15 @@ Feature: DVLA Driving licence - Auth Source
         And I can see the check details formatted issueDate value as 22 08 2023
         And I can see the check details formatted validTo value as 27 04 2025
 
+    @mock-api:dl-dvla-auth-success @validation-regression
+    Scenario: DVLA Auth Source - User clicks the back button
+        When I click on the Yes radio button
+        Then I click on the Confirm and Continue button
+        And I should be on the DVLA consent page We need to check your driving licence details – GOV.UK One Login
+        Then I see the back button on the DVLA check your details page with text Back
+        And User clicks the back button
+        Then I should be on the Driving Licence check your details page Check your UK photocard driving licence details – GOV.UK One Login
+
     @mock-api:dl-dvla-auth-success @validation-regression @accessibility
     Scenario: DVLA Auth Source - Axe Accessibility Scan - Driving Licence Check Your Details Page
         Then I run the Axe Accessibility check against the Driving Licence check your details page

--- a/test/browser/features/Welsh/DVA/WelshDVA.feature
+++ b/test/browser/features/Welsh/DVA/WelshDVA.feature
@@ -8,18 +8,18 @@ Feature: DVA Driving licence CRI Error Validations - Welsh Translation
     And I add a cookie to change the language to Welsh
 
   @mock-api:dva-PageHeading @language-regression
-  Scenario:User Selects DVA and landed in DVA page and Page title and sub-text
+  Scenario: DVA - Welsh Translation Tests - User Selects DVA and landed in DVA page and Page title and sub-text
     Given I check the page Title Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
     Then I see the heading Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru
     And I see sentence Os nad oes gennych drwydded yrru y DU neu os na allwch gofio'ch manylion, gallwch brofi pwy ydych chi mewn ffordd arall yn lle.
 
   @mock-api:dva-WelshBetaBanner @language-regression
-  Scenario: Beta Banner
+  Scenario: DVA - Welsh Translation Tests - Beta Banner
     Given I view the BETA banner
     And the beta banner reads Mae hwn yn wasanaeth newydd. Helpwch ni i'w wella a rhoi eich adborth (agor mewn tab newydd).
 
   @mock-api:dva-WelshBetaBanner @language-regression
-  Scenario: Footer Links and Text
+  Scenario: DVA - Welsh Translation Tests - Footer Links and Text
     Given I see the accessibility statement link Datganiad hygyrchedd
     And I see the cookies link Cwcis
     And I see the terms and conditions link Telerau ac amodau
@@ -29,7 +29,7 @@ Feature: DVA Driving licence CRI Error Validations - Welsh Translation
     And I see the crown copyright link © Hawlfraint y goron
 
   @mock-api:dva-NameFiled @language-regression
-  Scenario: DVA Name fields
+  Scenario: DVA - Welsh Translation Tests - DVA Name fields
     Given I can see the lastname as Enw olaf
     And I can see the givenName as Enwau a roddwyd
     And I can see the firstName as Enw cyntaf
@@ -38,7 +38,7 @@ Feature: DVA Driving licence CRI Error Validations - Welsh Translation
     And I can see the middle name sentence Gadewch hyn yn wag os nad oes gennych unrhyw enwau canol
 
   @mock-api:dva-DoBField @language-regression
-  Scenario: DVA DoB Field
+  Scenario: DVA - Welsh Translation Tests - DVA DoB Field
     Given I can see the DVA DoB fields titled Dyddiad geni
     Then I can see DVA DoB example DVA as Er enghraifft, 5 9 1973
     Then I can see DVA day as Diwrnod
@@ -46,7 +46,7 @@ Feature: DVA Driving licence CRI Error Validations - Welsh Translation
     And I can see DVA year as Blwyddyn
 
   @mock-api:dva-IssueField @language-regression
-  Scenario: DVA Issue date field
+  Scenario: DVA - Welsh Translation Tests - DVA Issue date field
     Given I see the DVA Issue date field titled Dyddiad cyhoeddi
     Then I see DVA date section example as Dyma'r dyddiad yn adran 4a o'ch trwydded, er enghraifft 27 5 2019
     Then I can see DVA Issue day as Diwrnod
@@ -54,7 +54,7 @@ Feature: DVA Driving licence CRI Error Validations - Welsh Translation
     And I can see DVA issue year as Blwyddyn
 
   @mock-api:dva-ValidToDateField @language-regression
-  Scenario: DVLA Valid to date field
+  Scenario: DVA - Welsh Translation Tests - DVLA Valid to date field
     Given I can see the Valid to date field titled Yn ddilys tan
     And I can see Valid to date sentence as Dyma'r dyddiad yn adran 4b o'ch trwydded, er enghraifft 27 5 2019
     Then I can see Valid To day as Diwrnod
@@ -62,17 +62,17 @@ Feature: DVA Driving licence CRI Error Validations - Welsh Translation
     Then I can see Valid To year as Blwyddyn
 
   @mock-api:dva-LicenceField @language-regression
-  Scenario: DVA Licence number
+  Scenario: DVA - Welsh Translation Tests - DVA Licence number
     Given I can see DVA licence number field titled as Rhif trwydded
     And I see the DVA licence sentence as Dyma'r rhif hir yn adran 5 ar eich trwydded
 
   @mock-api:dva-PostcodeField @language-regression
-  Scenario: DVA Postcode
+  Scenario: DVA - Welsh Translation Tests - DVA Postcode
     Given I can see the postcode field titled Cod post
     Then I can see postcode sentence as Rhowch y cod post yn y cyfeiriad yn adran 8 o'ch trwydded
 
   @mock-api:dva-ConsentSection @validation-regression @Language-regression
-  Scenario: DVA Driving Licence privacy notice link to consent
+  Scenario: DVA - Welsh Translation Tests - DVA Driving Licence privacy notice link to consent
     Given I see the consent title section Caniatau DVA i wirio eich manylion trwydded yrru
     And I see the DVA Consent first sentence Mae DVA angen eich caniatâd i wirio eich manylion trwydded yrru cyn y gallwch barhau. Byddant yn sicrhau nad yw eich trwydded wedi cael ei chanslo na'i hadrodd fel un sydd ar goll neu wedi'i dwyn.
     And I see the DVA Consent second sentence I ddarganfod mwy am sut bydd eich manylion trwydded yrru yn cael eu defnyddio, gallwch ddarllen:
@@ -82,7 +82,7 @@ Feature: DVA Driving licence CRI Error Validations - Welsh Translation
   ##### Summary Error Validation ######
 
   @mock-api:dva-invalidDrivingLicenceNumber @language-regression
-  Scenario Outline: DVA Driving Licence number less than 8 characters error validation
+  Scenario Outline: DVA - Welsh Translation Tests - DVA Driving Licence number less than 8 characters error validation
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     And DVA User re-enters drivingLicenceNumber as <InvalidLicenceNumber>
     When User clicks on continue
@@ -94,7 +94,7 @@ Feature: DVA Driving licence CRI Error Validations - Welsh Translation
       | DrivingLicenceSubjectHappyBilly | 5566778              |
 
   @mock-api:dva-invalidDrivingLicenceNumber @language-regression
-  Scenario Outline: DVA Driving Licence number with special characters and spaces error validation
+  Scenario Outline: DVA - Welsh Translation Tests - DVA Driving Licence number with special characters and spaces error validation
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     And DVA User re-enters drivingLicenceNumber as <InvalidLicenceNumber>
     When User clicks on continue
@@ -107,7 +107,7 @@ Feature: DVA Driving licence CRI Error Validations - Welsh Translation
 
   ##### DrivingLicenceNumberWithAlphaNumericChar, DrivingLicenceNumberWithAlphaChar, NoDrivingLicenceNumber #####
   @mock-api:dva-invalidDrivingLicenceNumber @language-regression
-  Scenario Outline: DVA Driving Licence number with alpha numeric characters or alpha characters or no licence number error validation
+  Scenario Outline: DVA - Welsh Translation Tests - DVA Driving Licence number with alpha numeric characters or alpha characters or no licence number error validation
     Given DVA User re-enters drivingLicenceNumber as <DVADrivingLicenceSubject>
     And DVA User re-enters drivingLicenceNumber as <InvalidLicenceNumber>
     When User clicks on continue
@@ -121,7 +121,7 @@ Feature: DVA Driving licence CRI Error Validations - Welsh Translation
       | DrivingLicenceSubjectHappyBilly | XYZabdAB             |
 
   @mock-api:dva-invalidPostcode @language-regression
-  Scenario Outline: DVA Driving Licence Postcode less than 5 characters error validation
+  Scenario Outline: DVA - Welsh Translation Tests - DVA Driving Licence Postcode less than 5 characters error validation
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     And User re-enters postcode as <InvalidPostcode>
     When User clicks on continue
@@ -133,7 +133,7 @@ Feature: DVA Driving licence CRI Error Validations - Welsh Translation
       | DrivingLicenceSubjectHappyBilly | E20A            |
 
   @mock-api:dva-invalidPostcode @language-regression
-  Scenario Outline: DVA Driving Licence - No Postcode in the Postcode field error validation
+  Scenario Outline: DVA - Welsh Translation Tests - DVA Driving Licence - No Postcode in the Postcode field error validation
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     And User re-enters postcode as <InvalidPostcode>
     When User clicks on continue
@@ -145,7 +145,7 @@ Feature: DVA Driving licence CRI Error Validations - Welsh Translation
       | DrivingLicenceSubjectHappyBilly |                 |
 
   @mock-api:dva-invalidPostcode @language-regression
-  Scenario Outline: DVA Driving Licence International Postcode error validation
+  Scenario Outline: DVA - Welsh Translation Tests - DVA Driving Licence International Postcode error validation
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     And User re-enters postcode as <InvalidPostcode>
     When User clicks on continue
@@ -158,7 +158,7 @@ Feature: DVA Driving licence CRI Error Validations - Welsh Translation
 
   ###### PostcodeWithSpecialChar #####
   @mock-api:dva-invalidPostcode @language-regression
-  Scenario Outline: DVA Driving Licence Postcode with special characters error validation
+  Scenario Outline: DVA - Welsh Translation Tests - DVA Driving Licence Postcode with special characters error validation
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     And User re-enters postcode as <InvalidPostcode>
     When User clicks on continue
@@ -171,7 +171,7 @@ Feature: DVA Driving licence CRI Error Validations - Welsh Translation
 
   ####### PostcodeWithNumericChar, PostcodeWithAlphaChar #####
   @mock-api:dva-invalidPostcode @language-regression
-  Scenario Outline: DVA Driving Licence Postcode with numeric characters or alpha characters error validation
+  Scenario Outline: DVA - Welsh Translation Tests - DVA Driving Licence Postcode with numeric characters or alpha characters error validation
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     And User re-enters postcode as <InvalidPostcode>
     When User clicks on continue
@@ -185,7 +185,7 @@ Feature: DVA Driving licence CRI Error Validations - Welsh Translation
 
   ######  InvalidLastNameWithNumbers, InvalidLastNameWithSpecialCharacters, NoLastName #####
   @mock-api:dva-invalidLastName @language-regression
-  Scenario Outline: DVA Driving Licence Last name with numbers or special characters or no last name error validation
+  Scenario Outline: DVA - Welsh Translation Tests - DVA Driving Licence Last name with numbers or special characters or no last name error validation
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     And User re-enters last name as <InvalidLastName>
     When User clicks on continue
@@ -200,7 +200,7 @@ Feature: DVA Driving licence CRI Error Validations - Welsh Translation
 
   ######  InvalidFirstNameWithNumbers, InvalidFirstNameWithSpecialCharacters, NoFirstName #####
   @mock-api:dva-invalidFirstName @language-regression
-  Scenario Outline: DVA Driving Licence First name with numbers or special characters or no first name error validation
+  Scenario Outline: DVA - Welsh Translation Tests - DVA Driving Licence First name with numbers or special characters or no first name error validation
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     And User re-enters first name as <InvalidFirstName>
     When User clicks on continue
@@ -215,7 +215,7 @@ Feature: DVA Driving licence CRI Error Validations - Welsh Translation
 
   #######  InvalidMiddleNamesWithNumbers, InvalidMiddleNamesWithSpecialCharacters #####
   @mock-api:dva-invalidMiddleNames @language-regression
-  Scenario Outline: DVA Driving Licence Middle names with numbers or special characters error validation
+  Scenario Outline: DVA - Welsh Translation Tests - DVA Driving Licence Middle names with numbers or special characters error validation
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     And User re-enters middle names as <InvalidMiddleNames>
     When User clicks on continue
@@ -229,7 +229,7 @@ Feature: DVA Driving licence CRI Error Validations - Welsh Translation
 
   #####  DateOfBirthNotReal, DateOfBirthWithSpecialCharacters, NoDateOfBirth ##### Need confirmation with summary
   @mock-api:dva-invalidDateOfBirth @language-regression
-  Scenario Outline: DVA Driving Licence Date of birth that are not real or with special characters or no date of birth error validation
+  Scenario Outline: DVA - Welsh Translation Tests - DVA Driving Licence Date of birth that are not real or with special characters or no date of birth error validation
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     And DVA user re-enters day of birth as <InvalidDayOfBirth>
     And DVA user re-enters month of birth as <InvalidMonthOfBirth>
@@ -245,7 +245,7 @@ Feature: DVA Driving licence CRI Error Validations - Welsh Translation
       | DrivingLicenceSubjectHappyBilly |                   |                     |                    |
 
   @mock-api:dva-invalidDateOfBirth @language-regression
-  Scenario Outline: DVA Driving Licence Date of birth in the future error validation
+  Scenario Outline: DVA - Welsh Translation Tests - DVA Driving Licence Date of birth in the future error validation
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     And DVA user re-enters day of birth as <InvalidDayOfBirth>
     And DVA user re-enters month of birth as <InvalidMonthOfBirth>
@@ -260,7 +260,7 @@ Feature: DVA Driving licence CRI Error Validations - Welsh Translation
 
   #####  IssueDateWithAlphaCharacters, IssueDateWithSpecialCharacters, NoIssueDate #####
   @mock-api:dva-invalidIssueDate @language-regression
-  Scenario Outline: DVA Driving Licence Issue date that are not real or with special characters or no issue date error validation
+  Scenario Outline: DVA - Welsh Translation Tests - DVA Driving Licence Issue date that are not real or with special characters or no issue date error validation
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     And DVA user re-enters day of issue as <InvalidDayOfIssue>
     And DVA user re-enters month of issue as <InvalidMonthOfIssue>
@@ -276,7 +276,7 @@ Feature: DVA Driving licence CRI Error Validations - Welsh Translation
       | DrivingLicenceSubjectHappyBilly |                   |                     |                    |
 
   @mock-api:dva-invalidIssueDate @language-regression
-  Scenario Outline: DVA Driving Licence Issue date in the future error validation
+  Scenario Outline: DVA - Welsh Translation Tests - DVA Driving Licence Issue date in the future error validation
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     And DVA user re-enters day of issue as <InvalidDayOfIssue>
     And DVA user re-enters month of issue as <InvalidMonthOfIssue>
@@ -291,7 +291,7 @@ Feature: DVA Driving licence CRI Error Validations - Welsh Translation
 
   #####  InvalidValidToDate, ValidToDateWithSpecialCharacters, NoValidToDate  #####
   @mock-api:dva-invalidExpiryDate @language-regression
-  Scenario Outline: DVA Driving Licence Valid to date that are not real or with special characters or no valid to date error validation
+  Scenario Outline: DVA - Welsh Translation Tests - DVA Driving Licence Valid to date that are not real or with special characters or no valid to date error validation
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     And User re-enters valid to day as <InvalidValidToDay>
     And User re-enters valid to month as <InvalidValidToMonth>
@@ -307,7 +307,7 @@ Feature: DVA Driving licence CRI Error Validations - Welsh Translation
       | DrivingLicenceSubjectHappyBilly |                   |                     |                    |
 
   @mock-api:dva-invalidExpiryDate @language-regression
-  Scenario Outline: DVA Driving Licence Valid to date in the past error validation
+  Scenario Outline: DVA - Welsh Translation Tests - DVA Driving Licence Valid to date in the past error validation
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     And User re-enters valid to day as <InvalidValidToDay>
     And User re-enters valid to month as <InvalidValidToMonth>
@@ -321,7 +321,7 @@ Feature: DVA Driving licence CRI Error Validations - Welsh Translation
       | DrivingLicenceSubjectHappyBilly | 10                | 01                  | 2010               |
 
   @mock-api:dva-ConsentError @language-regression
-  Scenario Outline:  DVA Driving Licence error validation when DVA consent checkbox is unselected
+  Scenario Outline: DVA - Welsh Translation Tests - DVA Driving Licence error validation when DVA consent checkbox is unselected
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     And DVA consent checkbox is unselected
     When User clicks on continue
@@ -333,7 +333,7 @@ Feature: DVA Driving licence CRI Error Validations - Welsh Translation
       | DrivingLicenceSubjectHappyBilly |
 
   @mock-api:dl-failed @language-regression
-  Scenario Outline: DVA Retry Message
+  Scenario Outline: DVA - Welsh Translation Tests - DVA Retry Message
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     And DVA User re-enters drivingLicenceNumber as <InvalidLicenceNumber>
     When User clicks on continue
@@ -344,3 +344,9 @@ Feature: DVA Driving licence CRI Error Validations - Welsh Translation
     Examples:
       | DVADrivingLicenceSubject        | InvalidLicenceNumber |
       | DrivingLicenceSubjectHappyBilly | 55667778             |
+
+  @mock-api:dva-WelshBackButton @language-regression
+  Scenario: DVA - Welsh Translation Tests - User clicks the back button
+    Given I see the back button on the DVA details page with text Yn ôl
+    And User clicks the back button
+    And I see the Landing Page Title Summary Text Mae hwn i'w weld yn adran 4c o'ch trwydded yrru. Bydd naill ai’n dweud DVLA (Asiantaeth Trwyddedu Gyrru a Cherbydau) neu DVA (Asiantaeth Gyrwyr a Cherbydau).

--- a/test/browser/features/Welsh/DVA/WelshDVAAuthSource.feature
+++ b/test/browser/features/Welsh/DVA/WelshDVAAuthSource.feature
@@ -56,3 +56,12 @@ Feature: DVA Driving licence - Auth Source - Welsh Translation
         And I should be on the DVA consent page Rydym angen gwirio manylion eich trwydded yrru – GOV.UK One Login
         And I can see the consent page title as Rydym angen gwirio manylion eich trwydded yrru gyda'r DVA
         And I can see the consent page text as Caniatau DVA i wirio eich manylion trwydded yrru
+
+    @mock-api:dl-dva-auth-success @language-regression
+    Scenario: DVA Auth Source - Welsh Translation Tests - User clicks the back button
+        When I click on the Yes radio button
+        Then I click on the Confirm and Continue button
+        And I should be on the DVA consent page Rydym angen gwirio manylion eich trwydded yrru – GOV.UK One Login
+        Then I see the back button on the DVA check your details page with text Yn ôl
+        And User clicks the back button
+        Then I should be on the Driving Licence check your details page Gwirio manylion eich trwydded yrru cerdyn-llun yn y DU – GOV.UK One Login

--- a/test/browser/features/Welsh/DVLA/WelshDVLA.feature
+++ b/test/browser/features/Welsh/DVLA/WelshDVLA.feature
@@ -8,18 +8,18 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
     And I add a cookie to change the language to Welsh
 
   @mock-api:dvla-PageHeading @language-regression
-  Scenario:User Selects DVLA and landed in DVLA page and Page title and sub-text
+  Scenario: DVLA - Welsh Translation Tests - User Selects DVLA and landed in DVLA page and Page title and sub-text
     Given I check the page Title Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
     Then I see the heading Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru
     And I see sentence Os nad oes gennych drwydded yrru y DU neu os na allwch gofio'ch manylion, gallwch brofi pwy ydych chi mewn ffordd arall yn lle.
 
   @mock-api:dvla-WelshBetaBanner @language-regression
-  Scenario: Beta Banner
+  Scenario: DVLA - Welsh Translation Tests - Beta Banner
     Given I view the BETA banner
     And the beta banner reads Mae hwn yn wasanaeth newydd. Helpwch ni i'w wella a rhoi eich adborth (agor mewn tab newydd).
 
   @mock-api:dvla-WelshBetaBanner @language-regression
-  Scenario: Footer Links and Text
+  Scenario: DVLA - Welsh Translation Tests - Footer Links and Text
     Given I see the accessibility statement link Datganiad hygyrchedd
     And I see the cookies link Cwcis
     And I see the terms and conditions link Telerau ac amodau
@@ -29,7 +29,7 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
     And I see the crown copyright link © Hawlfraint y goron
 
   @mock-api:dvla-NameField @language-regression
-  Scenario: DVLA Name fields
+  Scenario: DVLA - Welsh Translation Tests - DVLA Name fields
     Given I can see the lastname as Enw olaf
     And I can see the givenName as Enwau a roddwyd
     And I can see the firstName as Enw cyntaf
@@ -38,7 +38,7 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
     And I can see the middle name sentence Gadewch hyn yn wag os nad oes gennych unrhyw enwau canol
 
   @mock-api:dvla-DobField @language-regression
-  Scenario: DVLA DoB Fields
+  Scenario: DVLA - Welsh Translation Tests - DVLA DoB Fields
     Given I can see the DoB fields titled Dyddiad geni
     When I can see example as Er enghraifft, 5 9 1973
     Then I can see date as Diwrnod
@@ -47,7 +47,7 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
 
   @mock-api:dvla-IssueDateField @language-regression
   @Language-regression
-  Scenario: DVLA Issue date fields
+  Scenario: DVLA - Welsh Translation Tests - DVLA Issue date fields
     Given I can see the Issue date field titled Dyddiad cyhoeddi
     Then I can see Issue date sentence as Dyma'r dyddiad yn adran 4a o'ch trwydded, er enghraifft 27 5 2019
     And I can see issue day as Diwrnod
@@ -55,7 +55,7 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
     And I can see issue year as Blwyddyn
 
   @mock-api:dvla-ValidToDateField @language-regression
-  Scenario: DVLA Valid to date field
+  Scenario: DVLA - Welsh Translation Tests - DVLA Valid to date field
     Given I can see the Valid to date field titled Yn ddilys tan
     And I can see Valid to date sentence as Dyma'r dyddiad yn adran 4b o'ch trwydded, er enghraifft 27 5 2019
     Then I can see Valid To day as Diwrnod
@@ -63,22 +63,22 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
     Then I can see Valid To year as Blwyddyn
 
   @mock-api:dvla-LicenceField @language-regression
-  Scenario: DVLA Licence number
+  Scenario: DVLA - Welsh Translation Tests - DVLA Licence number
     Given I can see the licence number field titled Rhif trwydded
     Then I see the Licence number sentence Dyma'r rhif hir yn adran 5 ar eich trwydded er enghraifft HARRI559146MJ931
 
   @mock-api:dvla-IssueNumberField @language-regression
-  Scenario: DVLA Issue number
+  Scenario: DVLA - Welsh Translation Tests - DVLA Issue number
     Given I can see the issue number field titled Rhif cyhoeddi
     And I can see issue sentence as Dyma'r rhif 2 ddigid ar ôl y gofod yn adran 5 o'ch trwydded
 
   @mock-api:dvla-PostcodeField @language-regression
-  Scenario: DVLA Postcode
+  Scenario: DVLA - Welsh Translation Tests - DVLA Postcode
     Given I can see the postcode field titled Cod post
     Then I can see postcode sentence as Rhowch y cod post yn y cyfeiriad yn adran 8 o'ch trwydded
 
   @mock-api:dvla-consentSection @language-regression
-  Scenario: DVLA Driving Licence privacy notice link to consent
+  Scenario: DVLA - Welsh Translation Tests - DVLA Driving Licence privacy notice link to consent
     Given I see the consent title section Caniatau DVLA i wirio eich manylion trwydded yrru
     And I see the DVLA Consent first sentence Mae DVLA angen eich caniatâd i wirio eich manylion trwydded yrru cyn y gallwch barhau. Byddant yn sicrhau nad yw eich trwydded wedi cael ei chanslo na'i hadrodd fel un sydd ar goll neu wedi'i dwyn.
     And I see the DVLA Consent second sentence I ddarganfod mwy am sut bydd eich manylion trwydded yrru yn cael eu defnyddio, gallwch ddarllen:
@@ -88,7 +88,7 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
   #### Summary Error validation ######
 
   @mock-api:dvla-unhappyPath @language-regression
-  Scenario Outline: DVLA Driving Licence details page unhappy path when licence number date format does not match with User's Date Of Birth
+  Scenario Outline: DVLA - Welsh Translation Tests - DVLA Driving Licence details page unhappy path when licence number date format does not match with User's Date Of Birth
     Given User enters DVLA data as a <DrivingLicenceSubject>
     And User re-enters day of birth as <InvalidDayOfBirth>
     And User re-enters month of birth as <InvalidMonthOfBirth>
@@ -105,7 +105,7 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
 
   #####  InvalidLastNameWithNumbers, InvalidLastNameWithSpecialCharacters, NoLastName #####
   @mock-api:dvla-invalidLastName @language-regression
-  Scenario Outline: DVLA Driving Licence Last name with numbers or special characters or no last name error validation
+  Scenario Outline: DVLA - Welsh Translation Tests - DVLA Driving Licence Last name with numbers or special characters or no last name error validation
     Given User enters DVLA data as a <DrivingLicenceSubject>
     And User re-enters last name as <InvalidLastName>
     When User clicks on continue
@@ -120,7 +120,7 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
 
   #####  InvalidFirstNameWithNumbers, InvalidFirstNameWithSpecialCharacters, NoFirstName #####
   @mock-api:dvla-invalidFirstName @language-regression
-  Scenario Outline: DVLA Driving Licence First name with numbers or special characters or no first name error validation
+  Scenario Outline: DVLA - Welsh Translation Tests - DVLA Driving Licence First name with numbers or special characters or no first name error validation
     Given User enters DVLA data as a <DrivingLicenceSubject>
     And User re-enters first name as <InvalidFirstName>
     When User clicks on continue
@@ -135,7 +135,7 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
 
   #####  InvalidMiddleNamesWithNumbers, InvalidMiddleNamesWithSpecialCharacters #####
   @mock-api:dvla-invalidMiddleNames @language-regression
-  Scenario Outline: DVLA Driving Licence Middle names with numbers or special characters error validation
+  Scenario Outline: DVLA - Welsh Translation Tests - DVLA Driving Licence Middle names with numbers or special characters error validation
     Given User enters DVLA data as a <DrivingLicenceSubject>
     And User re-enters middle names as <InvalidMiddleNames>
     When User clicks on continue
@@ -149,7 +149,7 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
 
   #####  DateOfBirthWithSpecialCharacters, DateOfBirthNotReal, NoDateOfBirth #####
   @mock-api:dvla-invalidDateOfBirth @language-regression
-  Scenario Outline: DVLA Driving Licence Date of birth that are not real or with special characters or no date of birth error validation
+  Scenario Outline: DVLA - Welsh Translation Tests - DVLA Driving Licence Date of birth that are not real or with special characters or no date of birth error validation
     Given User enters DVLA data as a <DrivingLicenceSubject>
     And User re-enters day of birth as <InvalidDayOfBirth>
     And User re-enters month of birth as <InvalidMonthOfBirth>
@@ -166,7 +166,7 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
   #|DrivingLicenceSubjectHappyPeter|                 |                   |                |
 
   @mock-api:dvla-invalidDateOfBirth @language-regression
-  Scenario Outline: DVLA Driving Licence Date of birth in the future error validation
+  Scenario Outline: DVLA - Welsh Translation Tests - DVLA Driving Licence Date of birth in the future error validation
     Given User enters DVLA data as a <DrivingLicenceSubject>
     And User re-enters day of birth as <InvalidDayOfBirth>
     And User re-enters month of birth as <InvalidMonthOfBirth>
@@ -181,7 +181,7 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
 
   #####  InvalidIssueDate, NoIssueDate #####
   @mock-api:dvla-invalidIssueDate @language-regression
-  Scenario Outline: DVLA Driving Licence Issue date that are not real or with special characters or no issue date error validation
+  Scenario Outline: DVLA - Welsh Translation Tests - DVLA Driving Licence Issue date that are not real or with special characters or no issue date error validation
     Given User enters DVLA data as a <DrivingLicenceSubject>
     And User re-enters day of issue as <InvalidDayOfIssue>
     And User re-enters month of issue as <InvalidMonthOfIssue>
@@ -198,7 +198,7 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
       | DrivingLicenceSubjectHappyPeter |                   |                     |                    |
 
   @mock-api:dvla-invalidIssueDate @language-regression
-  Scenario Outline: DVLA Driving Licence Issue date in the future error validation
+  Scenario Outline: DVLA - Welsh Translation Tests - DVLA Driving Licence Issue date in the future error validation
     Given User enters DVLA data as a <DrivingLicenceSubject>
     And User re-enters day of issue as <InvalidDayOfIssue>
     And User re-enters month of issue as <InvalidMonthOfIssue>
@@ -213,7 +213,7 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
 
   ####  InvalidValidToDate, ValidToDateWithSpecialCharacters, NoValidToDate  #####
   @mock-api:dvla-invalidExpiryDate @language-regression
-  Scenario Outline: DVLA Driving Licence Valid to date that are not real or with special characters or no valid to date error validation
+  Scenario Outline: DVLA - Welsh Translation Tests - DVLA Driving Licence Valid to date that are not real or with special characters or no valid to date error validation
     Given User enters DVLA data as a <DrivingLicenceSubject>
     And User re-enters valid to day as <InvalidValidToDay>
     And User re-enters valid to month as <InvalidValidToMonth>
@@ -229,7 +229,7 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
       | DrivingLicenceSubjectHappyPeter |                   |                     |                    |
 
   @mock-api:dvla-invalidExpiryDate @language-regression
-  Scenario Outline: DVLA Driving Licence Valid to date in the past error validation
+  Scenario Outline: DVLA - Welsh Translation Tests - DVLA Driving Licence Valid to date in the past error validation
     Given User enters DVLA data as a <DrivingLicenceSubject>
     And User re-enters valid to day as <InvalidValidToDay>
     And User re-enters valid to month as <InvalidValidToMonth>
@@ -243,7 +243,7 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
       | DrivingLicenceSubjectHappyPeter | 10                | 01                  | 2010               |
 
   @mock-api:dvla-invalidDrivingLicenceNumber @language-regression
-  Scenario Outline: DVLA Driving Licence number less than 16 characters error validation
+  Scenario Outline: DVLA - Welsh Translation Tests - DVLA Driving Licence number less than 16 characters error validation
     Given User enters DVLA data as a <DrivingLicenceSubject>
     And User re-enters drivingLicenceNumber as <InvalidLicenceNumber>
     When User clicks on continue
@@ -255,7 +255,7 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
       | DrivingLicenceSubjectHappyPeter | PARKE610112PBF       |
 
   @mock-api:dvla-invalidDrivingLicenceNumber @language-regression
-  Scenario Outline: DVLA Driving Licence number with special characters and spaces error validation
+  Scenario Outline: DVLA - Welsh Translation Tests - DVLA Driving Licence number with special characters and spaces error validation
     Given User enters DVLA data as a <DrivingLicenceSubject>
     And User re-enters drivingLicenceNumber as <InvalidLicenceNumber>
     When User clicks on continue
@@ -268,7 +268,7 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
 
   ####### DrivingLicenceNumberWithNumericChar, DrivingLicenceNumberWithAlphaChar, NoDrivingLicenceNumber #######
   @mock-api:dvla-invalidDrivingLicenceNumber @language-regression
-  Scenario Outline: DVLA Driving Licence number with numeric characters or alpha characters or no licence number error validation
+  Scenario Outline: DVLA - Welsh Translation Tests - DVLA Driving Licence number with numeric characters or alpha characters or no licence number error validation
     Given User enters DVLA data as a <DrivingLicenceSubject>
     And User re-enters drivingLicenceNumber as <InvalidLicenceNumber>
     When User clicks on continue
@@ -282,7 +282,7 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
       | DrivingLicenceSubjectHappyPeter |                      |
 
   @mock-api:dvla-invalidIssueNumber @language-regression
-  Scenario Outline: DVLA Driving Licence Issue number less than 2 characters error validation
+  Scenario Outline: DVLA - Welsh Translation Tests - DVLA Driving Licence Issue number less than 2 characters error validation
     Given User enters DVLA data as a <DrivingLicenceSubject>
     And User re-enters issue number as <InvalidIssueNumber>
     When User clicks on continue
@@ -294,7 +294,7 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
       | DrivingLicenceSubjectHappyPeter | 1                  |
 
   @mock-api:dvla-invalidIssueNumber @language-regression
-  Scenario Outline: DVLA Driving Licence Issue number with special characters error validation
+  Scenario Outline: DVLA - Welsh Translation Tests - DVLA Driving Licence Issue number with special characters error validation
     Given User enters DVLA data as a <DrivingLicenceSubject>
     And User re-enters issue number as <InvalidIssueNumber>
     When User clicks on continue
@@ -307,7 +307,7 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
 
   ##### IssueNumberWithAlphanumericChar, IssueNumberWithAlphaChar, NoIssueNumber #####
   @mock-api:dvla-invalidIssueNumber @language-regression
-  Scenario Outline: DVLA Driving Licence Issue number with alphanumeric characters or alpha characters No issue number error validation
+  Scenario Outline: DVLA - Welsh Translation Tests - DVLA Driving Licence Issue number with alphanumeric characters or alpha characters No issue number error validation
     Given User enters DVLA data as a <DrivingLicenceSubject>
     And User re-enters issue number as <InvalidIssueNumber>
     When User clicks on continue
@@ -321,7 +321,7 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
   #     |DrivingLicenceSubjectHappyPeter|AB                |bug rasied - LIME-751
 
   @mock-api:dvla-invalidPostcode @language-regression
-  Scenario Outline: DVLA Driving Licence Postcode less than 5 characters error validation
+  Scenario Outline: DVLA - Welsh Translation Tests - DVLA Driving Licence Postcode less than 5 characters error validation
     Given User enters DVLA data as a <DrivingLicenceSubject>
     And User re-enters postcode as <InvalidPostcode>
     When User clicks on continue
@@ -333,7 +333,7 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
       | DrivingLicenceSubjectHappyPeter | E20A            |
 
   @mock-api:dvla-invalidPostcode @language-regression
-  Scenario Outline: DVLA Driving Licence - No Postcode in the Postcode field error validation
+  Scenario Outline: DVLA - Welsh Translation Tests - DVLA Driving Licence - No Postcode in the Postcode field error validation
     Given User enters DVLA data as a <DrivingLicenceSubject>
     And User re-enters postcode as <InvalidPostcode>
     When User clicks on continue
@@ -345,7 +345,7 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
       | DrivingLicenceSubjectHappyPeter |                 |
 
   @mock-api:dvla-invalidPostcode @language-regression
-  Scenario Outline: DVLA Driving Licence International Postcode error validation
+  Scenario Outline: DVLA - Welsh Translation Tests - DVLA Driving Licence International Postcode error validation
     Given User enters DVLA data as a <DrivingLicenceSubject>
     And User re-enters postcode as <InvalidPostcode>
     When User clicks on continue
@@ -358,7 +358,7 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
 
   ##### PostcodeWithSpecialChar #####
   @mock-api:dvla-invalidPostcode @language-regression
-  Scenario Outline: DVLA Driving Licence Postcode with special characters error validation
+  Scenario Outline: DVLA - Welsh Translation Tests - DVLA Driving Licence Postcode with special characters error validation
     Given User enters DVLA data as a <DrivingLicenceSubject>
     And User re-enters postcode as <InvalidPostcode>
     When User clicks on continue
@@ -371,7 +371,7 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
 
   ###### PostcodeWithNumericChar, PostcodeWithAlphaChar #####  (need clarification)
   @mock-api:dvla-invalidPostcode @language-regression
-  Scenario Outline: DVLA Driving Licence Postcode with numeric characters or alpha characters error validation
+  Scenario Outline: DVLA - Welsh Translation Tests - DVLA Driving Licence Postcode with numeric characters or alpha characters error validation
     Given User enters DVLA data as a <DrivingLicenceSubject>
     And User re-enters postcode as <InvalidPostcode>
     When User clicks on continue
@@ -385,7 +385,7 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
 
   ##### Consent Checkbox Unselected error Validation ##### (passed)
   @mock-api:dvla-Consent-checkbox-error @language-regression
-  Scenario Outline: DVLA Driving Licence error validation when DVLA consent checkbox is unselected
+  Scenario Outline: DVLA - Welsh Translation Tests - DVLA Driving Licence error validation when DVLA consent checkbox is unselected
     Given User enters DVLA data as a <DrivingLicenceSubject>
     And DVLA consent checkbox is unselected
     When User clicks on continue
@@ -398,7 +398,7 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
 
   ##### Retry message #####
   @mock-api:dl-failed @language-regression
-  Scenario Outline:Retry message
+  Scenario Outline: DVLA - Welsh Translation Tests - Retry message
     Given User enters DVLA data as a <DrivingLicenceSubject>
     And User re-enters drivingLicenceNumber as <InvalidLicenceNumber>
     And User re-enters last name as <InvalidLastName>
@@ -412,3 +412,9 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
     Examples:
       | DrivingLicenceSubject             | InvalidLicenceNumber | InvalidLastName | InvalidFirstName | InvalidMiddleNames |
       | DrivingLicenceSubjectHappyKenneth | AB999607085JAAAA     | JOHN            | SMITH            | A                  |
+
+  @mock-api:dvla-BackButton @language-regression
+  Scenario: DVLA - Welsh Translation Tests - User clicks the back button
+    Given I see the back button on the DVLA details page with text Yn ôl
+    And User clicks the back button
+    Then I see the Landing Page Title Summary Text Mae hwn i'w weld yn adran 4c o'ch trwydded yrru. Bydd naill ai’n dweud DVLA (Asiantaeth Trwyddedu Gyrru a Cherbydau) neu DVA (Asiantaeth Gyrwyr a Cherbydau).

--- a/test/browser/features/Welsh/DVLA/WelshDVLAAuthSource.feature
+++ b/test/browser/features/Welsh/DVLA/WelshDVLAAuthSource.feature
@@ -57,3 +57,12 @@ Feature: DVLA Driving licence - Auth Source - Welsh Translation
         And I should be on the DVLA consent page Rydym angen gwirio manylion eich trwydded yrru – GOV.UK One Login
         And I can see the consent page title as Rydym angen gwirio manylion eich trwydded yrru
         And I can see the consent page text as Caniatau DVLA i wirio eich manylion trwydded yrru
+
+    @mock-api:dl-dvla-auth-success @language-regression
+    Scenario: DVLA Auth Source - Welsh Translation Tests - User clicks the back button
+        When I click on the Yes radio button
+        Then I click on the Confirm and Continue button
+        And I should be on the DVLA consent page Rydym angen gwirio manylion eich trwydded yrru – GOV.UK One Login
+        Then I see the back button on the DVLA check your details page with text Yn ôl
+        And User clicks the back button
+        Then I should be on the Driving Licence check your details page Gwirio manylion eich trwydded yrru cerdyn-llun yn y DU – GOV.UK One Login

--- a/test/browser/pages/CheckYourDetailsPage.js
+++ b/test/browser/pages/CheckYourDetailsPage.js
@@ -14,6 +14,8 @@ exports.CheckYourDetailsPage = class PlaywrightDevPage {
       'xpath=//*[@id="main-content"]/div/div/form/button'
     );
 
+    this.backButton = this.page.locator('xpath=//*[@id="back"]/a');
+
     this.betaBanner = this.page.locator("xpath=/html/body/div[2]/div/p/strong");
 
     this.betaBannerReads = this.page.locator(
@@ -330,5 +332,10 @@ exports.CheckYourDetailsPage = class PlaywrightDevPage {
     await expect(await this.validToValue.textContent()).to.contains(
       checkYourDetailsValidToFormattedValue
     );
+  }
+
+  async assertBackButtonText(backButtonText) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(await this.backButton.innerText()).to.equal(backButtonText);
   }
 };

--- a/test/browser/pages/DVADetailsEntryPage.js
+++ b/test/browser/pages/DVADetailsEntryPage.js
@@ -61,6 +61,8 @@ exports.DVADetailsEntryPage = class PlaywrightDevPage {
       'xpath=//*[@id="main-content"]/div/div/p[8]/a'
     );
 
+    this.backButton = this.page.locator('xpath=//*[@id="back"]/a');
+
     // DVA Error summary items
 
     this.dvaErrorSummaryBoxLicenceNumber = this.page.locator(
@@ -509,5 +511,11 @@ exports.DVADetailsEntryPage = class PlaywrightDevPage {
 
   async goToPage(pageName) {
     await this.page.goto(this.page.url() + pageName);
+  }
+
+  async assertBackButtonText(backButtonText) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(await this.isCurrentPage()).to.be.true;
+    expect(await this.backButton.innerText()).to.equal(backButtonText);
   }
 };

--- a/test/browser/pages/DrivingLicencePage.js
+++ b/test/browser/pages/DrivingLicencePage.js
@@ -49,6 +49,8 @@ exports.DrivingLicencePage = class PlaywrightDevPage {
       'xpath=//*[@id="main-content"]/div/div/p[6]/a'
     );
 
+    this.backButton = this.page.locator('xpath=//*[@id="back"]/a');
+
     // Error summary items
 
     this.invalidLastNameErrorInSummary = this.page.locator(
@@ -983,5 +985,11 @@ exports.DrivingLicencePage = class PlaywrightDevPage {
     }
 
     return true;
+  }
+
+  async assertBackButtonText(backButtonText) {
+    await this.page.waitForLoadState("domcontentloaded");
+    expect(await this.isCurrentPage()).to.be.true;
+    expect(await this.backButton.innerText()).to.equal(backButtonText);
   }
 };

--- a/test/browser/pages/UniversalSteps.js
+++ b/test/browser/pages/UniversalSteps.js
@@ -4,6 +4,7 @@ exports.UniversalSteps = class PlaywrightDevPage {
   constructor(page, url) {
     this.page = page;
     this.url = url;
+    this.backButton = this.page.locator('xpath=//*[@id="back"]/a');
   }
 
   async changeLanguageTo(language) {
@@ -33,5 +34,10 @@ exports.UniversalSteps = class PlaywrightDevPage {
   async assertURLContains(expected) {
     const url = await this.driver.getCurrentUrl();
     assertTrue(url.contains(expected));
+  }
+
+  async clickBackButton() {
+    await this.backButton.click();
+    await this.page.waitForTimeout(2000); //waitForNavigation and waitForLoadState do not work in this case
   }
 };

--- a/test/browser/step_definitions/CheckYourDetailsStepDefs.js
+++ b/test/browser/step_definitions/CheckYourDetailsStepDefs.js
@@ -269,3 +269,19 @@ Then(
     await checkYourDetailsPage.assertHintText(checkYourDetailsHintTextText);
   }
 );
+
+Given(
+  /^I see the back button on the DVA check your details page with text (.*)$/,
+  async function (backButtonText) {
+    const checkYourDetailsPage = new CheckYourDetailsPage(this.page);
+    await checkYourDetailsPage.assertBackButtonText(backButtonText);
+  }
+);
+
+Given(
+  /^I see the back button on the DVLA check your details page with text (.*)$/,
+  async function (backButtonText) {
+    const checkYourDetailsPage = new CheckYourDetailsPage(this.page);
+    await checkYourDetailsPage.assertBackButtonText(backButtonText);
+  }
+);

--- a/test/browser/step_definitions/DrivingLicenceStepDefs.js
+++ b/test/browser/step_definitions/DrivingLicenceStepDefs.js
@@ -1079,3 +1079,19 @@ Then(
     await dvaDetailsEntryPage.assertDVAConsentOneLoginLink(consentOneLoginLink);
   }
 );
+
+Given(
+  /^I see the back button on the DVA details page with text (.*)$/,
+  async function (backButtonText) {
+    const dvaDetailsEntryPage = new DVADetailsEntryPage(this.page);
+    await dvaDetailsEntryPage.assertBackButtonText(backButtonText);
+  }
+);
+
+Given(
+  /^I see the back button on the DVLA details page with text (.*)$/,
+  async function (backButtonText) {
+    const drivingLicencePage = new DrivingLicencePage(this.page);
+    await drivingLicencePage.assertBackButtonText(backButtonText);
+  }
+);

--- a/test/browser/step_definitions/UniversalStepDefs.js
+++ b/test/browser/step_definitions/UniversalStepDefs.js
@@ -9,3 +9,8 @@ Then(
     await universalSteps.changeLanguageTo(language);
   }
 );
+
+Then(/^User clicks the back button$/, async function () {
+  const universalSteps = new UniversalSteps(this.page);
+  await universalSteps.clickBackButton();
+});


### PR DESCRIPTION
## Proposed changes

Tests added for all journeys (DVA/ DVLA, DVA Auth Source/ DVLA Auth Source) English and Welsh Test checks for back button, confirms text is correct, clicks the back button, and validates it is back on the correct page

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->




### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1831](https://govukverify.atlassian.net/browse/LIME-1831)

### Other considerations

All Tests passed locally:

![Uploading screencapture-file-Users-chrisbates-GitHub-ipv-cri-dl-front-reports-cucumber-report-html-2025-08-28-12_34_36.png…]()



[LIME-1831]: https://govukverify.atlassian.net/browse/LIME-1831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ